### PR TITLE
Add Drift schema initialization with sample repository/test

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -7,9 +7,14 @@ import 'tables.dart';
 
 part 'app_database.g.dart';
 
-@DriftDatabase(tables: [Books, Memos])
+@DriftDatabase(
+  tables: [Books, Notes, Actions, ReadingLogs],
+  daos: [BookDao, NoteDao, ActionDao, ReadingLogDao],
+)
 class AppDatabase extends _$AppDatabase {
-  AppDatabase() : super(_openConnection());
+  AppDatabase({QueryExecutor? executor}) : super(executor ?? _openConnection());
+
+  AppDatabase.forTesting(QueryExecutor executor) : super(executor);
 
   @override
   int get schemaVersion => 1;
@@ -21,4 +26,53 @@ LazyDatabase _openConnection() {
     final file = File(p.join(dbFolder.path, 'book_memoly.db'));
     return NativeDatabase(file);
   });
+}
+
+@DriftAccessor(tables: [Books])
+class BookDao extends DatabaseAccessor<AppDatabase> with _$BookDaoMixin {
+  BookDao(AppDatabase db) : super(db);
+
+  Future<int> insertBook(BooksCompanion entry) => into(books).insert(entry);
+
+  Future<List<BookRow>> getAllBooks() => select(books).get();
+
+  Stream<List<BookRow>> watchAllBooks() => select(books).watch();
+}
+
+@DriftAccessor(tables: [Notes])
+class NoteDao extends DatabaseAccessor<AppDatabase> with _$NoteDaoMixin {
+  NoteDao(AppDatabase db) : super(db);
+
+  Future<int> insertNote(NotesCompanion entry) => into(notes).insert(entry);
+
+  Future<List<NoteRow>> getNotesForBook(int bookId) {
+    return (select(notes)..where((tbl) => tbl.bookId.equals(bookId))).get();
+  }
+}
+
+@DriftAccessor(tables: [Actions])
+class ActionDao extends DatabaseAccessor<AppDatabase> with _$ActionDaoMixin {
+  ActionDao(AppDatabase db) : super(db);
+
+  Future<int> insertAction(ActionsCompanion entry) =>
+      into(actions).insert(entry);
+
+  Future<List<ActionRow>> getPendingActions() {
+    return (select(actions)..where((tbl) => tbl.status.equals('pending')))
+        .get();
+  }
+}
+
+@DriftAccessor(tables: [ReadingLogs])
+class ReadingLogDao extends DatabaseAccessor<AppDatabase>
+    with _$ReadingLogDaoMixin {
+  ReadingLogDao(AppDatabase db) : super(db);
+
+  Future<int> insertLog(ReadingLogsCompanion entry) =>
+      into(readingLogs).insert(entry);
+
+  Future<List<ReadingLogRow>> getLogsForBook(int bookId) {
+    return (select(readingLogs)..where((tbl) => tbl.bookId.equals(bookId)))
+        .get();
+  }
 }

--- a/lib/core/database/tables.dart
+++ b/lib/core/database/tables.dart
@@ -1,5 +1,6 @@
 import 'package:drift/drift.dart';
 
+@DataClassName('BookRow')
 class Books extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get googleBooksId => text()();
@@ -9,16 +10,47 @@ class Books extends Table {
   TextColumn get thumbnailUrl => text().nullable()();
   TextColumn get publishedDate => text().nullable()();
   IntColumn get pageCount => integer().nullable()();
-  IntColumn get status => integer()(); // 0: unread, 1: reading, 2: finished
-  DateTimeColumn get createdAt => dateTime()();
-  DateTimeColumn get updatedAt => dateTime()();
+  IntColumn get status => integer()
+      .withDefault(const Constant(0))(); // 0: unread, 1: reading, 2: finished
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 }
 
-class Memos extends Table {
+@DataClassName('NoteRow')
+class Notes extends Table {
   IntColumn get id => integer().autoIncrement()();
-  IntColumn get bookId => integer()();
+  IntColumn get bookId =>
+      integer().references(Books, #id, onDelete: KeyAction.cascade)();
   TextColumn get content => text()();
   IntColumn get pageNumber => integer().nullable()();
-  DateTimeColumn get createdAt => dateTime()();
-  DateTimeColumn get updatedAt => dateTime()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+@DataClassName('ActionRow')
+class Actions extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get bookId => integer()
+      .nullable()
+      .references(Books, #id, onDelete: KeyAction.cascade)();
+  TextColumn get title => text()();
+  TextColumn get description => text().nullable()();
+  DateTimeColumn get dueDate => dateTime().nullable()();
+  TextColumn get status =>
+      text().withDefault(const Constant('pending'))(); // pending, done, skipped
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+@DataClassName('ReadingLogRow')
+class ReadingLogs extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get bookId =>
+      integer().references(Books, #id, onDelete: KeyAction.cascade)();
+  IntColumn get startPage => integer().nullable()();
+  IntColumn get endPage => integer().nullable()();
+  IntColumn get durationMinutes => integer().nullable()();
+  DateTimeColumn get loggedAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 }

--- a/lib/core/repositories/local_database_repository.dart
+++ b/lib/core/repositories/local_database_repository.dart
@@ -1,0 +1,80 @@
+import 'package:drift/drift.dart';
+
+import '../database/app_database.dart';
+
+class LocalDatabaseRepository {
+  LocalDatabaseRepository(this.db)
+      : books = BookDao(db),
+        notes = NoteDao(db),
+        actions = ActionDao(db),
+        readingLogs = ReadingLogDao(db);
+
+  final AppDatabase db;
+  final BookDao books;
+  final NoteDao notes;
+  final ActionDao actions;
+  final ReadingLogDao readingLogs;
+
+  /// Seeds the database with sample data and returns what was inserted to
+  /// verify SELECT/INSERT flow works end-to-end.
+  Future<SampleDataResult> insertAndReadSampleData() async {
+    final bookId = await books.insertBook(
+      BooksCompanion.insert(
+        googleBooksId: 'sample-google-books-id',
+        title: 'Sample Drift Book',
+        authors: const Value('Sample Author'),
+      ),
+    );
+
+    await notes.insertNote(
+      NotesCompanion.insert(
+        bookId: bookId,
+        content: 'This is a sample note for drift verification.',
+        pageNumber: const Value(12),
+      ),
+    );
+
+    await actions.insertAction(
+      ActionsCompanion.insert(
+        title: 'Capture insights from sample book',
+        bookId: Value(bookId),
+        status: const Value('pending'),
+      ),
+    );
+
+    await readingLogs.insertLog(
+      ReadingLogsCompanion.insert(
+        bookId: bookId,
+        startPage: const Value(1),
+        endPage: const Value(18),
+        durationMinutes: const Value(25),
+      ),
+    );
+
+    final booksResult = await books.getAllBooks();
+    final notesResult = await notes.getNotesForBook(bookId);
+    final actionsResult = await actions.getPendingActions();
+    final logsResult = await readingLogs.getLogsForBook(bookId);
+
+    return SampleDataResult(
+      book: booksResult.firstWhere((row) => row.id == bookId),
+      notes: notesResult,
+      actions: actionsResult,
+      readingLogs: logsResult,
+    );
+  }
+}
+
+class SampleDataResult {
+  SampleDataResult({
+    required this.book,
+    required this.notes,
+    required this.actions,
+    required this.readingLogs,
+  });
+
+  final BookRow book;
+  final List<NoteRow> notes;
+  final List<ActionRow> actions;
+  final List<ReadingLogRow> readingLogs;
+}

--- a/test/core/database/app_database_test.dart
+++ b/test/core/database/app_database_test.dart
@@ -1,0 +1,30 @@
+import 'package:book_memoly_app/core/database/app_database.dart';
+import 'package:book_memoly_app/core/repositories/local_database_repository.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+  late LocalDatabaseRepository repository;
+
+  setUp(() {
+    db = AppDatabase(executor: NativeDatabase.memory());
+    repository = LocalDatabaseRepository(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('Drift can INSERT and SELECT sample data', () async {
+    final result = await repository.insertAndReadSampleData();
+
+    expect(result.book.id, greaterThan(0));
+    expect(result.notes, isNotEmpty);
+    expect(result.actions, isNotEmpty);
+    expect(result.readingLogs, isNotEmpty);
+
+    final fetchedNotes = await repository.notes.getNotesForBook(result.book.id);
+    expect(fetchedNotes.first.content, contains('sample note'));
+  });
+}


### PR DESCRIPTION
## Summary
- add Drift tables for books, notes, actions, and reading logs with defaults and FK constraints
- wire DAOs into AppDatabase and provide repository helper to seed/read sample data
- add memory-backed Drift test to verify INSERT/SELECT flow
- run build_runner to refresh generated outputs

## Testing
- flutter test test/core/database/app_database_test.dart
- flutter pub run build_runner build --delete-conflicting-outputs
