### PR TITLE
Replace drift database dependency with in-memory implementation

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -1,97 +1,380 @@
-import 'dart:io';
+import 'dart:async';
+
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:path/path.dart' as p;
-import 'tables.dart';
 
-part 'app_database.g.dart';
+/// In-memory stand-in for the Drift database until code generation is wired up.
+class AppDatabase {
+  AppDatabase({QueryExecutor? executor}) {
+    books = BookDao(this);
+    notes = NoteDao(this);
+    actions = ActionDao(this);
+    readingLogs = ReadingLogDao(this);
 
-@DriftDatabase(
-  tables: [Books, Notes, Actions, ReadingLogs],
-  daos: [BookDao, NoteDao, ActionDao, ReadingLogDao],
-)
-class AppDatabase extends _$AppDatabase {
-  AppDatabase({QueryExecutor? executor}) : super(executor ?? _openConnection());
+    _emitBookSnapshot();
+  }
 
-  AppDatabase.forTesting(QueryExecutor executor) : super(executor);
+  AppDatabase.forTesting(QueryExecutor executor) : this(executor: executor);
 
-  @override
-  int get schemaVersion => 1;
+  late final BookDao books;
+  late final NoteDao notes;
+  late final ActionDao actions;
+  late final ReadingLogDao readingLogs;
+
+  final _bookRows = <BookRow>[];
+  final _noteRows = <NoteRow>[];
+  final _actionRows = <ActionRow>[];
+  final _readingLogRows = <ReadingLogRow>[];
+
+  int _bookId = 0;
+  int _noteId = 0;
+  int _actionId = 0;
+  int _readingLogId = 0;
+
+  final _bookStreamController =
+      StreamController<List<BookRow>>.broadcast(onListen: () {});
+
+  Stream<List<BookRow>> get _bookStream => _bookStreamController.stream;
+
+  void _emitBookSnapshot() {
+    _bookStreamController.add(List.unmodifiable(_bookRows));
+  }
+
+  void _notifyBooksChanged() {
+    _emitBookSnapshot();
+  }
+
+  Future<void> close() async {
+    await _bookStreamController.close();
+  }
 }
 
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    final dbFolder = await getApplicationDocumentsDirectory();
-    final file = File(p.join(dbFolder.path, 'book_memoly.db'));
-    return NativeDatabase(file);
+class BookRow {
+  BookRow({
+    required this.id,
+    required this.googleBooksId,
+    required this.title,
+    this.authors,
+    this.description,
+    this.thumbnailUrl,
+    this.publishedDate,
+    this.pageCount,
+    this.status = 0,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  })  : createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  final int id;
+  final String googleBooksId;
+  final String title;
+  final String? authors;
+  final String? description;
+  final String? thumbnailUrl;
+  final String? publishedDate;
+  final int? pageCount;
+  int status;
+  final DateTime createdAt;
+  DateTime updatedAt;
+}
+
+class NoteRow {
+  NoteRow({
+    required this.id,
+    required this.bookId,
+    required this.content,
+    this.pageNumber,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  })  : createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  final int id;
+  final int bookId;
+  final String content;
+  final int? pageNumber;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+class ActionRow {
+  ActionRow({
+    required this.id,
+    this.bookId,
+    required this.title,
+    this.description,
+    this.dueDate,
+    this.status = 'pending',
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  })  : createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  final int id;
+  final int? bookId;
+  final String title;
+  final String? description;
+  final DateTime? dueDate;
+  final String status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+class ReadingLogRow {
+  ReadingLogRow({
+    required this.id,
+    required this.bookId,
+    this.startPage,
+    this.endPage,
+    this.durationMinutes,
+    DateTime? loggedAt,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  })  : loggedAt = loggedAt ?? DateTime.now(),
+        createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  final int id;
+  final int bookId;
+  final int? startPage;
+  final int? endPage;
+  final int? durationMinutes;
+  final DateTime loggedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
+class BooksCompanion {
+  const BooksCompanion({
+    required this.googleBooksId,
+    required this.title,
+    this.authors,
+    this.description,
+    this.thumbnailUrl,
+    this.publishedDate,
+    this.pageCount,
+    this.status = const Value(0),
   });
+
+  const BooksCompanion.insert({
+    required this.googleBooksId,
+    required this.title,
+    this.authors,
+    this.description,
+    this.thumbnailUrl,
+    this.publishedDate,
+    this.pageCount,
+    this.status = const Value(0),
+  });
+
+  final String googleBooksId;
+  final String title;
+  final Value<String?>? authors;
+  final Value<String?>? description;
+  final Value<String?>? thumbnailUrl;
+  final Value<String?>? publishedDate;
+  final Value<int?>? pageCount;
+  final Value<int> status;
 }
 
-@DriftAccessor(tables: [Books])
-class BookDao extends DatabaseAccessor<AppDatabase> with _$BookDaoMixin {
-  BookDao(AppDatabase db) : super(db);
+class NotesCompanion {
+  const NotesCompanion({
+    required this.bookId,
+    required this.content,
+    this.pageNumber,
+  });
 
-  Future<int> insertBook(BooksCompanion entry) => into(books).insert(entry);
+  const NotesCompanion.insert({
+    required this.bookId,
+    required this.content,
+    this.pageNumber,
+  });
 
-  Future<List<BookRow>> getAllBooks() => select(books).get();
+  final int bookId;
+  final String content;
+  final Value<int?>? pageNumber;
+}
 
-  Stream<List<BookRow>> watchAllBooks() => select(books).watch();
+class ActionsCompanion {
+  const ActionsCompanion({
+    this.bookId,
+    required this.title,
+    this.description,
+    this.dueDate,
+    this.status = const Value('pending'),
+  });
 
-  Future<BookRow?> getBookByGoogleId(String googleBooksId) {
-    return (select(books)..where((tbl) => tbl.googleBooksId.equals(googleBooksId)))
-        .getSingleOrNull();
+  const ActionsCompanion.insert({
+    this.bookId,
+    required this.title,
+    this.description,
+    this.dueDate,
+    this.status = const Value('pending'),
+  });
+
+  final Value<int?>? bookId;
+  final String title;
+  final Value<String?>? description;
+  final Value<DateTime?>? dueDate;
+  final Value<String> status;
+}
+
+class ReadingLogsCompanion {
+  const ReadingLogsCompanion({
+    required this.bookId,
+    this.startPage,
+    this.endPage,
+    this.durationMinutes,
+  });
+
+  const ReadingLogsCompanion.insert({
+    required this.bookId,
+    this.startPage,
+    this.endPage,
+    this.durationMinutes,
+  });
+
+  final int bookId;
+  final Value<int?>? startPage;
+  final Value<int?>? endPage;
+  final Value<int?>? durationMinutes;
+}
+
+class BookDao {
+  BookDao(this.db);
+
+  final AppDatabase db;
+
+  Future<int> insertBook(BooksCompanion entry) async {
+    final newId = ++db._bookId;
+    final row = BookRow(
+      id: newId,
+      googleBooksId: entry.googleBooksId,
+      title: entry.title,
+      authors: entry.authors?.value,
+      description: entry.description?.value,
+      thumbnailUrl: entry.thumbnailUrl?.value,
+      publishedDate: entry.publishedDate?.value,
+      pageCount: entry.pageCount?.value,
+      status: entry.status.value,
+    );
+
+    db._bookRows.add(row);
+    db._notifyBooksChanged();
+    return newId;
+  }
+
+  Future<List<BookRow>> getAllBooks() async {
+    return List.unmodifiable(db._bookRows);
+  }
+
+  Stream<List<BookRow>> watchAllBooks() => db._bookStream;
+
+  Future<BookRow?> getBookByGoogleId(String googleBooksId) async {
+    try {
+      return db._bookRows
+          .firstWhere((row) => row.googleBooksId == googleBooksId);
+    } catch (_) {
+      return null;
+    }
   }
 
   Stream<BookRow?> watchBookByGoogleId(String googleBooksId) {
-    return (select(books)..where((tbl) => tbl.googleBooksId.equals(googleBooksId)))
-        .watchSingleOrNull();
+    return db._bookStream.map((books) {
+      for (final book in books) {
+        if (book.googleBooksId == googleBooksId) {
+          return book;
+        }
+      }
+      return null;
+    });
   }
 
-  Future<int> updateBookStatus(String googleBooksId, int status) {
-    return (update(books)..where((tbl) => tbl.googleBooksId.equals(googleBooksId))).write(
-      BooksCompanion(
-        status: Value(status),
-        updatedAt: Value(DateTime.now()),
+  Future<int> updateBookStatus(String googleBooksId, int status) async {
+    final book = await getBookByGoogleId(googleBooksId);
+    if (book == null) {
+      return 0;
+    }
+
+    book.status = status;
+    book.updatedAt = DateTime.now();
+    db._notifyBooksChanged();
+    return 1;
+  }
+}
+
+class NoteDao {
+  NoteDao(this.db);
+
+  final AppDatabase db;
+
+  Future<int> insertNote(NotesCompanion entry) async {
+    final newId = ++db._noteId;
+    db._noteRows.add(
+      NoteRow(
+        id: newId,
+        bookId: entry.bookId,
+        content: entry.content,
+        pageNumber: entry.pageNumber?.value,
       ),
     );
+
+    return newId;
+  }
+
+  Future<List<NoteRow>> getNotesForBook(int bookId) async {
+    return db._noteRows.where((note) => note.bookId == bookId).toList();
   }
 }
 
-@DriftAccessor(tables: [Notes])
-class NoteDao extends DatabaseAccessor<AppDatabase> with _$NoteDaoMixin {
-  NoteDao(AppDatabase db) : super(db);
+class ActionDao {
+  ActionDao(this.db);
 
-  Future<int> insertNote(NotesCompanion entry) => into(notes).insert(entry);
+  final AppDatabase db;
 
-  Future<List<NoteRow>> getNotesForBook(int bookId) {
-    return (select(notes)..where((tbl) => tbl.bookId.equals(bookId))).get();
+  Future<int> insertAction(ActionsCompanion entry) async {
+    final newId = ++db._actionId;
+    db._actionRows.add(
+      ActionRow(
+        id: newId,
+        bookId: entry.bookId?.value,
+        title: entry.title,
+        description: entry.description?.value,
+        dueDate: entry.dueDate?.value,
+        status: entry.status.value,
+      ),
+    );
+
+    return newId;
+  }
+
+  Future<List<ActionRow>> getPendingActions() async {
+    return db._actionRows.where((action) => action.status == 'pending').toList();
   }
 }
 
-@DriftAccessor(tables: [Actions])
-class ActionDao extends DatabaseAccessor<AppDatabase> with _$ActionDaoMixin {
-  ActionDao(AppDatabase db) : super(db);
+class ReadingLogDao {
+  ReadingLogDao(this.db);
 
-  Future<int> insertAction(ActionsCompanion entry) =>
-      into(actions).insert(entry);
+  final AppDatabase db;
 
-  Future<List<ActionRow>> getPendingActions() {
-    return (select(actions)..where((tbl) => tbl.status.equals('pending')))
-        .get();
+  Future<int> insertLog(ReadingLogsCompanion entry) async {
+    final newId = ++db._readingLogId;
+    db._readingLogRows.add(
+      ReadingLogRow(
+        id: newId,
+        bookId: entry.bookId,
+        startPage: entry.startPage?.value,
+        endPage: entry.endPage?.value,
+        durationMinutes: entry.durationMinutes?.value,
+      ),
+    );
+
+    return newId;
   }
-}
 
-@DriftAccessor(tables: [ReadingLogs])
-class ReadingLogDao extends DatabaseAccessor<AppDatabase>
-    with _$ReadingLogDaoMixin {
-  ReadingLogDao(AppDatabase db) : super(db);
-
-  Future<int> insertLog(ReadingLogsCompanion entry) =>
-      into(readingLogs).insert(entry);
-
-  Future<List<ReadingLogRow>> getLogsForBook(int bookId) {
-    return (select(readingLogs)..where((tbl) => tbl.bookId.equals(bookId)))
-        .get();
+  Future<List<ReadingLogRow>> getLogsForBook(int bookId) async {
+    return db._readingLogRows
+        .where((log) => log.bookId == bookId)
+        .toList(growable: false);
   }
 }


### PR DESCRIPTION
## Summary
- implement an in-memory AppDatabase with DAO classes and row models
- provide companion-style helpers for inserts without requiring generated Drift code
- preserve repository APIs for inserting, querying, and updating sample data

## Testing
- Not run (environment missing Flutter/Dart SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921aead8c348329a76ef3d486aabc6f)