### PR TITLE
Add local book and memo search

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -343,6 +343,10 @@ class NoteDao {
 
   final AppDatabase db;
 
+  Future<List<NoteRow>> getAllNotes() async {
+    return List.unmodifiable(db._noteRows);
+  }
+
   Future<int> insertNote(NotesCompanion entry) async {
     final newId = ++db._noteId;
     db._noteRows.add(

--- a/lib/features/search/search_feature.dart
+++ b/lib/features/search/search_feature.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -6,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/models/book.dart';
 import '../../core/providers/database_providers.dart';
+import '../../core/repositories/local_database_repository.dart';
 import '../../shared/constants/app_constants.dart';
 
 final _dioProvider = Provider<Dio>((ref) {
@@ -192,14 +195,117 @@ class BookSearchNotifier extends StateNotifier<SearchState> {
   }
 }
 
-class SearchPage extends ConsumerStatefulWidget {
+class LocalSearchState {
+  const LocalSearchState({
+    required this.results,
+    this.hasSearched = false,
+    this.keyword = '',
+    this.statusFilter,
+  });
+
+  static const _statusFilterSentinel = Object();
+
+  final AsyncValue<List<LocalSearchResult>> results;
+  final bool hasSearched;
+  final String keyword;
+  final BookStatus? statusFilter;
+
+  LocalSearchState copyWith({
+    AsyncValue<List<LocalSearchResult>>? results,
+    bool? hasSearched,
+    String? keyword,
+    Object? statusFilter = _statusFilterSentinel,
+  }) {
+    return LocalSearchState(
+      results: results ?? this.results,
+      hasSearched: hasSearched ?? this.hasSearched,
+      keyword: keyword ?? this.keyword,
+      statusFilter: statusFilter == _statusFilterSentinel
+          ? this.statusFilter
+          : statusFilter as BookStatus?,
+    );
+  }
+}
+
+final localSearchNotifierProvider =
+    StateNotifierProvider<LocalSearchNotifier, LocalSearchState>((ref) {
+  final repository = ref.read(localDatabaseRepositoryProvider);
+  return LocalSearchNotifier(repository);
+});
+
+class LocalSearchNotifier extends StateNotifier<LocalSearchState> {
+  LocalSearchNotifier(this._repository)
+      : super(const LocalSearchState(results: AsyncValue.data([])));
+
+  final LocalDatabaseRepository _repository;
+
+  Future<void> search(String keyword) async {
+    final cleanedKeyword = keyword.trim();
+
+    state = state.copyWith(
+      results: const AsyncValue.loading(),
+      hasSearched: true,
+      keyword: cleanedKeyword,
+    );
+
+    try {
+      final results = await _repository.searchBooksAndNotes(
+        cleanedKeyword,
+        statusFilter: state.statusFilter,
+      );
+      state = state.copyWith(results: AsyncValue.data(results));
+    } catch (error, stackTrace) {
+      state = state.copyWith(results: AsyncValue.error(error, stackTrace));
+    }
+  }
+
+  void setStatusFilter(BookStatus? status) {
+    state = state.copyWith(statusFilter: status);
+
+    if (state.hasSearched && state.keyword.isNotEmpty) {
+      unawaited(search(state.keyword));
+    }
+  }
+}
+
+class SearchPage extends StatelessWidget {
   const SearchPage({super.key});
 
   @override
-  ConsumerState<SearchPage> createState() => _SearchPageState();
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('検索'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'オンライン検索'),
+              Tab(text: 'ローカル検索'),
+            ],
+          ),
+        ),
+        body: const SafeArea(
+          child: TabBarView(
+            children: [
+              _OnlineSearchTab(),
+              _LocalSearchTab(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
-class _SearchPageState extends ConsumerState<SearchPage> {
+class _OnlineSearchTab extends ConsumerStatefulWidget {
+  const _OnlineSearchTab();
+
+  @override
+  ConsumerState<_OnlineSearchTab> createState() => _OnlineSearchTabState();
+}
+
+class _OnlineSearchTabState extends ConsumerState<_OnlineSearchTab> {
   late final TextEditingController _keywordController;
 
   @override
@@ -218,58 +324,158 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   Widget build(BuildContext context) {
     final searchState = ref.watch(searchNotifierProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('書籍検索'),
-      ),
-      body: SafeArea(
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TextField(
-                    controller: _keywordController,
-                    decoration: const InputDecoration(
-                      labelText: 'キーワード',
-                      hintText: 'タイトルや著者名を入力（例: Effective Dart、村上春樹）',
-                      prefixIcon: Icon(Icons.search),
-                    ),
-                    textInputAction: TextInputAction.search,
-                    onSubmitted: (_) => _triggerSearch(),
-                  ),
-                  const SizedBox(height: 16),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed: _triggerSearch,
-                      icon: const Icon(Icons.search),
-                      label: const Text('検索する'),
-                    ),
-                  ),
-                ],
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _keywordController,
+                decoration: const InputDecoration(
+                  labelText: 'キーワード',
+                  hintText: 'タイトルや著者名を入力（例: Effective Dart、村上春樹）',
+                  prefixIcon: Icon(Icons.search),
+                ),
+                textInputAction: TextInputAction.search,
+                onSubmitted: (_) => _triggerSearch(),
               ),
-            ),
-            Expanded(
-              child: searchState.results.when(
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => _ErrorView(error: error),
-                data: (books) => _SearchResults(
-                  books: books,
-                  hasSearched: searchState.hasSearched,
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: _triggerSearch,
+                  icon: const Icon(Icons.search),
+                  label: const Text('検索する'),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
+        Expanded(
+          child: searchState.results.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => _ErrorView(error: error),
+            data: (books) => _SearchResults(
+              books: books,
+              hasSearched: searchState.hasSearched,
+            ),
+          ),
+        ),
+      ],
     );
   }
 
   void _triggerSearch() {
     ref.read(searchNotifierProvider.notifier).search(_keywordController.text);
+  }
+}
+
+class _LocalSearchTab extends ConsumerStatefulWidget {
+  const _LocalSearchTab();
+
+  @override
+  ConsumerState<_LocalSearchTab> createState() => _LocalSearchTabState();
+}
+
+class _LocalSearchTabState extends ConsumerState<_LocalSearchTab> {
+  late final TextEditingController _keywordController;
+
+  @override
+  void initState() {
+    super.initState();
+    _keywordController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _keywordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localSearchState = ref.watch(localSearchNotifierProvider);
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _keywordController,
+                decoration: const InputDecoration(
+                  labelText: 'キーワード',
+                  hintText: 'タイトル / 著者 / メモ内容 で検索',
+                  prefixIcon: Icon(Icons.search),
+                ),
+                textInputAction: TextInputAction.search,
+                onSubmitted: (_) => _triggerSearch(),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Icon(Icons.filter_alt_outlined),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: DropdownButton<BookStatus?>(
+                      value: localSearchState.statusFilter,
+                      isExpanded: true,
+                      hint: const Text('すべてのステータス'),
+                      items: [
+                        const DropdownMenuItem<BookStatus?>(
+                          value: null,
+                          child: Text('すべて'),
+                        ),
+                        ...BookStatus.values.map(
+                          (status) => DropdownMenuItem<BookStatus>(
+                            value: status,
+                            child: Text(status.label),
+                          ),
+                        ),
+                      ],
+                      onChanged: (status) {
+                        ref
+                            .read(localSearchNotifierProvider.notifier)
+                            .setStatusFilter(status);
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: _triggerSearch,
+                  icon: const Icon(Icons.manage_search),
+                  label: const Text('ローカルを検索'),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: localSearchState.results.when(
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => _ErrorView(error: error),
+            data: (results) => _LocalSearchResults(
+              results: results,
+              hasSearched: localSearchState.hasSearched,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _triggerSearch() {
+    ref
+        .read(localSearchNotifierProvider.notifier)
+        .search(_keywordController.text);
   }
 }
 
@@ -303,6 +509,119 @@ class _SearchResults extends StatelessWidget {
       itemBuilder: (context, index) {
         final book = books[index];
         return _BookListTile(book: book);
+      },
+    );
+  }
+}
+
+class _LocalSearchResults extends StatelessWidget {
+  const _LocalSearchResults({
+    required this.results,
+    required this.hasSearched,
+  });
+
+  final List<LocalSearchResult> results;
+  final bool hasSearched;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!hasSearched) {
+      return const Center(
+        child: Text('キーワードを入力して検索してください'),
+      );
+    }
+
+    if (results.isEmpty) {
+      return const Center(
+        child: Text('検索結果が見つかりませんでした'),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      itemCount: results.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        final result = results[index];
+        final status = bookStatusFromDbValue(result.book.status);
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        result.book.title,
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    Chip(
+                      label: Text(status.label),
+                      backgroundColor: Theme.of(context)
+                          .colorScheme
+                          .primary
+                          .withOpacity(0.1),
+                      labelStyle: TextStyle(
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                  ],
+                ),
+                if (result.book.authors?.isNotEmpty == true) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    result.book.authors!,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+                const SizedBox(height: 8),
+                if (result.matchingNotes.isNotEmpty) ...[
+                  Text(
+                    '一致したメモ (${result.matchingNotes.length})',
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelLarge
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 4),
+                  ...result.matchingNotes.take(3).map(
+                    (note) => Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text('• '),
+                          Expanded(
+                            child: Text(
+                              note.content,
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  if (result.matchingNotes.length > 3)
+                    Text(
+                      '他 ${result.matchingNotes.length - 3} 件のメモが一致',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                ] else
+                  Text(
+                    'タイトルや著者で一致しました',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+              ],
+            ),
+          ),
+        );
       },
     );
   }


### PR DESCRIPTION
## Summary
- add repository support for retrieving all notes and performing keyword searches across books and memos with status filters
- introduce a tabbed search screen that separates online Google Books searches from local library searches
- render local search results with status chips and matching memo excerpts for clearer context

## Testing
- not run (dart CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921bddeba288329abf4d499ed484ef9)