### PR TITLE
Add Supabase auth guard and user scoping

### DIFF
--- a/lib/core/database/tables.dart
+++ b/lib/core/database/tables.dart
@@ -3,6 +3,7 @@ import 'package:drift/drift.dart';
 @DataClassName('BookRow')
 class Books extends Table {
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get userId => text()();
   TextColumn get googleBooksId => text()();
   TextColumn get title => text()();
   TextColumn get authors => text().nullable()();
@@ -21,6 +22,7 @@ class Books extends Table {
 @DataClassName('NoteRow')
 class Notes extends Table {
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get userId => text()();
   IntColumn get bookId =>
       integer().references(Books, #id, onDelete: KeyAction.cascade)();
   TextColumn get content => text()();
@@ -32,6 +34,7 @@ class Notes extends Table {
 @DataClassName('ActionRow')
 class Actions extends Table {
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get userId => text()();
   IntColumn get bookId => integer()
       .nullable()
       .references(Books, #id, onDelete: KeyAction.cascade)();
@@ -50,6 +53,7 @@ class Actions extends Table {
 @DataClassName('ReadingLogRow')
 class ReadingLogs extends Table {
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get userId => text()();
   IntColumn get bookId =>
       integer().references(Books, #id, onDelete: KeyAction.cascade)();
   IntColumn get startPage => integer().nullable()();

--- a/lib/core/providers/auth_providers.dart
+++ b/lib/core/providers/auth_providers.dart
@@ -1,0 +1,44 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../services/auth_service.dart';
+import '../services/supabase_service.dart';
+
+final authServiceProvider = ChangeNotifierProvider<AuthService>((ref) {
+  final supabase = ref.watch(supabaseServiceProvider);
+  final service = AuthService(
+    client: supabase.client,
+    config: supabase.config,
+  );
+
+  ref.onDispose(service.dispose);
+  // Initialize after first frame to allow Supabase to be ready.
+  service.initialize();
+
+  return service;
+});
+
+final authSessionProvider = Provider<Session?>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return authService.state.session;
+});
+
+final currentUserIdProvider = Provider<String?>((ref) {
+  final session = ref.watch(authSessionProvider);
+  return session?.user.id;
+});
+
+final authStatusProvider = Provider<AuthStatus>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return authService.state.status;
+});
+
+final magicLinkSentProvider = Provider<bool>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return authService.state.magicLinkSent;
+});
+
+final authErrorMessageProvider = Provider<String?>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return authService.state.errorMessage;
+});

--- a/lib/core/providers/database_providers.dart
+++ b/lib/core/providers/database_providers.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../database/app_database.dart';
+import '../providers/auth_providers.dart';
 import '../repositories/local_database_repository.dart';
 
 final appDatabaseProvider = Provider<AppDatabase>((ref) {
@@ -11,8 +12,12 @@ final appDatabaseProvider = Provider<AppDatabase>((ref) {
 
 final localDatabaseRepositoryProvider =
     Provider<LocalDatabaseRepository>((ref) {
+  final userId = ref.watch(currentUserIdProvider);
+  if (userId == null) {
+    throw StateError('User must be logged in to access the database');
+  }
   final db = ref.watch(appDatabaseProvider);
-  return LocalDatabaseRepository(db);
+  return LocalDatabaseRepository(db, userId: userId);
 });
 
 final bookByGoogleIdProvider =

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,34 +1,65 @@
+import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../features/action_plans/action_plans_feature.dart';
+import '../../features/auth/login_page.dart';
 import '../../features/home/home_feature.dart';
 import '../../features/memos/memos_feature.dart';
-import '../../features/search/search_feature.dart';
-import '../../features/action_plans/action_plans_feature.dart';
 import '../../features/reading_speed/reading_speed_feature.dart';
+import '../../features/search/search_feature.dart';
+import '../providers/auth_providers.dart';
 
-final appRouter = GoRouter(
-  initialLocation: '/',
-  routes: [
-    GoRoute(
-      path: '/',
-      builder: (context, state) => const HomePage(),
-    ),
-    GoRoute(
-      path: '/search',
-      builder: (context, state) => const SearchPage(),
-    ),
-    GoRoute(
-      path: '/memos',
-      builder: (context, state) => const MemosPage(),
-    ),
-    GoRoute(
-      path: '/actions',
-      builder: (context, state) => const ActionPlansPage(),
-    ),
-    GoRoute(
-      path: '/reading-speed',
-      builder: (context, state) => const ReadingSpeedPage(),
-    ),
-  ],
-);
+final appRouterProvider = Provider<GoRouter>((ref) {
+  final authService = ref.watch(authServiceProvider);
 
+  return GoRouter(
+    initialLocation: '/login',
+    refreshListenable: authService,
+    redirect: (context, state) {
+      final status = authService.state.status;
+      final isLoggedIn = status == AuthStatus.authenticated;
+      final isLoggingIn = state.matchedLocation == '/login';
+
+      if (status == AuthStatus.loading) {
+        return null;
+      }
+
+      if (!isLoggedIn) {
+        return isLoggingIn ? null : '/login';
+      }
+
+      if (isLoggingIn) {
+        return '/';
+      }
+
+      return null;
+    },
+    routes: [
+      GoRoute(
+        path: '/login',
+        builder: (context, state) => const LoginPage(),
+      ),
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const HomePage(),
+      ),
+      GoRoute(
+        path: '/search',
+        builder: (context, state) => const SearchPage(),
+      ),
+      GoRoute(
+        path: '/memos',
+        builder: (context, state) => const MemosPage(),
+      ),
+      GoRoute(
+        path: '/actions',
+        builder: (context, state) => const ActionPlansPage(),
+      ),
+      GoRoute(
+        path: '/reading-speed',
+        builder: (context, state) => const ReadingSpeedPage(),
+      ),
+    ],
+  );
+});

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -1,0 +1,148 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../shared/config/supabase_config.dart';
+
+enum AuthStatus {
+  loading,
+  authenticated,
+  unauthenticated,
+}
+
+class AppAuthState {
+  const AppAuthState({
+    required this.status,
+    required this.session,
+    this.magicLinkSent = false,
+    this.errorMessage,
+  });
+
+  factory AppAuthState.initial() => const AppAuthState(
+        status: AuthStatus.loading,
+        session: null,
+      );
+
+  final AuthStatus status;
+  final Session? session;
+  final bool magicLinkSent;
+  final String? errorMessage;
+
+  AppAuthState copyWith({
+    AuthStatus? status,
+    Session? session,
+    bool? magicLinkSent,
+    String? errorMessage,
+  }) {
+    return AppAuthState(
+      status: status ?? this.status,
+      session: session ?? this.session,
+      magicLinkSent: magicLinkSent ?? this.magicLinkSent,
+      errorMessage: errorMessage,
+    );
+  }
+}
+
+class AuthService extends ChangeNotifier {
+  AuthService({
+    required SupabaseClient client,
+    SupabaseConfig? config,
+  })  : _client = client,
+        _config = config ?? SupabaseConfig.fromEnvironment();
+
+  final SupabaseClient _client;
+  final SupabaseConfig _config;
+
+  AppAuthState _state = AppAuthState.initial();
+  StreamSubscription<AuthState>? _authSubscription;
+  bool _initialized = false;
+
+  AppAuthState get state => _state;
+
+  String? get userId => _state.session?.user.id;
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+
+    _initialized = true;
+    _authSubscription =
+        _client.auth.onAuthStateChange.listen(_handleAuthStateChange);
+    await _loadInitialSession();
+    await _recoverSessionFromUrl();
+  }
+
+  Future<void> _loadInitialSession() async {
+    final session = _client.auth.currentSession;
+    _state = _state.copyWith(
+      session: session,
+      status: session != null ? AuthStatus.authenticated : AuthStatus.unauthenticated,
+    );
+    notifyListeners();
+  }
+
+  Future<void> _recoverSessionFromUrl([Uri? uri]) async {
+    final link = uri ?? Uri.base;
+    final hasAccessToken = link.queryParameters.containsKey('access_token');
+    final hasRefreshToken = link.queryParameters.containsKey('refresh_token');
+
+    if (!hasAccessToken || !hasRefreshToken) {
+      return;
+    }
+
+    try {
+      await _client.auth.getSessionFromUrl(link);
+    } catch (error) {
+      debugPrint('Failed to recover session from deep link: $error');
+    }
+  }
+
+  void _handleAuthStateChange(AuthState authState) {
+    final session = authState.session;
+    _state = _state.copyWith(
+      session: session,
+      status: session != null ? AuthStatus.authenticated : AuthStatus.unauthenticated,
+    );
+    notifyListeners();
+  }
+
+  Future<void> sendMagicLink(String email) async {
+    _state = _state.copyWith(magicLinkSent: false, errorMessage: null);
+    notifyListeners();
+
+    try {
+      await _client.auth.signInWithOtp(
+        email: email,
+        emailRedirectTo: _config.authRedirectUrl,
+      );
+      _state = _state.copyWith(magicLinkSent: true);
+    } catch (error, stackTrace) {
+      debugPrint('Magic link sign-in failed: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          context: const ErrorDescription('Magic link sign-in failed'),
+        ),
+      );
+      _state = _state.copyWith(
+        errorMessage: 'ログインリンクの送信に失敗しました。時間を置いて再試行してください。',
+        magicLinkSent: false,
+      );
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> signOut() async {
+    await _client.auth.signOut();
+  }
+
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/core/services/supabase_service.dart
+++ b/lib/core/services/supabase_service.dart
@@ -66,4 +66,6 @@ class SupabaseService {
   }
 
   SupabaseClient get client => Supabase.instance.client;
+
+  SupabaseConfig get config => _config;
 }

--- a/lib/features/auth/login_page.dart
+++ b/lib/features/auth/login_page.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../core/providers/auth_providers.dart';
+import '../../shared/constants/app_constants.dart';
+import '../../shared/widgets/app_button.dart';
+
+class LoginPage extends ConsumerStatefulWidget {
+  const LoginPage({super.key});
+
+  @override
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _sendMagicLink() async {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) {
+      return;
+    }
+
+    await ref.read(authServiceProvider).sendMagicLink(_emailController.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final magicLinkSent = ref.watch(magicLinkSentProvider);
+    final authError = ref.watch(authErrorMessageProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppConstants.appName),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'メールアドレスでログイン',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'メールアドレスを入力すると、ログイン用のMagic Linkを送信します。',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyLarge
+                    ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+              ),
+              const SizedBox(height: 24),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: _emailController,
+                      decoration: const InputDecoration(
+                        labelText: 'メールアドレス',
+                        border: OutlineInputBorder(),
+                      ),
+                      keyboardType: TextInputType.emailAddress,
+                      validator: (value) {
+                        if (value == null || value.isEmpty) {
+                          return 'メールアドレスを入力してください。';
+                        }
+                        if (!value.contains('@')) {
+                          return 'メールアドレスの形式が正しくありません。';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    AppButton(
+                      onPressed: _sendMagicLink,
+                      text: 'Magic Linkを送信',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (magicLinkSent)
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.secondaryContainer,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.mail_outline,
+                        color: Theme.of(context).colorScheme.secondary,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          'Magic Linkを送信しました。メールボックスを確認してください。',
+                          style: Theme.of(context).textTheme.bodyLarge,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              if (authError != null) ...[
+                const SizedBox(height: 12),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.errorContainer,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.error_outline,
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          authError,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyLarge
+                              ?.copyWith(color: Theme.of(context).colorScheme.onErrorContainer),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -1,18 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../core/providers/auth_providers.dart';
 import '../../shared/constants/app_constants.dart';
 import '../../shared/widgets/app_card.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends ConsumerWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(
         title: const Text(AppConstants.appName),
         centerTitle: true,
+        actions: [
+          IconButton(
+            tooltip: 'ログアウト',
+            onPressed: () async {
+              await ref.read(authServiceProvider).signOut();
+            },
+            icon: const Icon(Icons.logout),
+          ),
+        ],
       ),
       body: SafeArea(
         child: Padding(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,36 +8,30 @@ import 'shared/theme/app_theme.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  SupabaseService? supabaseService;
-  try {
-    supabaseService = SupabaseService();
-    await supabaseService.initialize();
-  } catch (e) {
-    debugPrint('Supabase initialization failed: $e');
-    debugPrint('App will continue without Supabase support.');
-  }
+  final supabaseService = SupabaseService();
+  await supabaseService.initialize();
 
   runApp(
     ProviderScope(
-      overrides: supabaseService != null
-          ? [supabaseServiceProvider.overrideWithValue(supabaseService)]
-          : [],
+      overrides: [supabaseServiceProvider.overrideWithValue(supabaseService)],
       child: const BookMemolyApp(),
     ),
   );
 }
 
-class BookMemolyApp extends StatelessWidget {
+class BookMemolyApp extends ConsumerWidget {
   const BookMemolyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+
     return MaterialApp.router(
       title: 'Book Memoly',
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: ThemeMode.system,
-      routerConfig: appRouter,
+      routerConfig: router,
     );
   }
 }

--- a/lib/shared/config/supabase_config.dart
+++ b/lib/shared/config/supabase_config.dart
@@ -3,18 +3,21 @@ class SupabaseConfig {
     required this.supabaseUrl,
     required this.supabaseAnonKey,
     this.healthCheckTable = 'health_checks',
+    this.authRedirectUrl,
   });
 
   factory SupabaseConfig.fromEnvironment() {
     return const SupabaseConfig(
       supabaseUrl: String.fromEnvironment('SUPABASE_URL'),
       supabaseAnonKey: String.fromEnvironment('SUPABASE_ANON_KEY'),
+      authRedirectUrl: String.fromEnvironment('SUPABASE_REDIRECT_URL'),
     );
   }
 
   final String supabaseUrl;
   final String supabaseAnonKey;
   final String healthCheckTable;
+  final String? authRedirectUrl;
 
   bool get isValid =>
       supabaseUrl.trim().isNotEmpty && supabaseAnonKey.trim().isNotEmpty;


### PR DESCRIPTION
## Summary
- introduce Supabase-authenticated routing with a dedicated login screen for magic link sign-in
- add authentication service/providers and wire Supabase config for redirect URLs
- scope in-app data structures to user IDs to mirror per-user isolation

## Testing
- flutter test *(fails: flutter not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224a114b8c832991317f13ca0ac404)