### PR TITLE
Add magic link resend support

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -705,7 +705,7 @@ packages:
     source: hosted
     version: "0.28.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
 
   # Utilities
   cupertino_icons: ^1.0.6
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a resend button on the login form to trigger the magic link flow again
- remember the last entered login email locally and prefill it when reopening the login screen
- store the address whenever the magic link is sent for consistent resend behavior

## Testing
- not run (Flutter SDK unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922698c21b88329b427fb7a90e269a7)