### PR TITLE
Adopt Material Symbols Rounded icons

### DIFF
--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'color_schemes.dart';
 import 'typography.dart';
+import '../../shared/constants/app_icons.dart';
 
 class AppTheme {
   static const _subThemes = FlexSubThemesData(
@@ -39,6 +40,15 @@ class AppTheme {
         fontFamily: primaryFontFamily,
         subThemesData: _subThemes,
         visualDensity: VisualDensity.adaptivePlatformDensity,
+      ).copyWith(
+        iconTheme: const IconThemeData(
+          size: AppIconSizes.medium,
+          color: lightColorScheme.onSurfaceVariant,
+        ),
+        primaryIconTheme: const IconThemeData(
+          size: AppIconSizes.medium,
+          color: lightColorScheme.onPrimary,
+        ),
       );
 
   static ThemeData get darkTheme => FlexThemeData.dark(
@@ -48,5 +58,14 @@ class AppTheme {
         fontFamily: primaryFontFamily,
         subThemesData: _subThemes,
         visualDensity: VisualDensity.adaptivePlatformDensity,
+      ).copyWith(
+        iconTheme: const IconThemeData(
+          size: AppIconSizes.medium,
+          color: darkColorScheme.onSurfaceVariant,
+        ),
+        primaryIconTheme: const IconThemeData(
+          size: AppIconSizes.medium,
+          color: darkColorScheme.onPrimary,
+        ),
       );
 }

--- a/lib/features/action_plans/action_plans_feature.dart
+++ b/lib/features/action_plans/action_plans_feature.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
+import '../../shared/constants/app_icons.dart';
 
 enum ActionStatusFilter { all, pending, done }
 
@@ -251,7 +252,7 @@ class ActionPlansPage extends ConsumerWidget {
                 ref,
                 bookId: state.selectedBookId!,
               ),
-              child: const Icon(Icons.add_task),
+              child: const Icon(AppIcons.addTask),
             )
           : null,
     );
@@ -271,14 +272,14 @@ class _BookSelector extends ConsumerWidget {
 
     if (state.books.isEmpty) {
       return const _InfoCard(
-        icon: Icons.menu_book,
+        icon: AppIcons.menuBook,
         message: 'まずは本を登録してアクションを追加しましょう',
       );
     }
 
     return Row(
       children: [
-        const Icon(Icons.menu_book_outlined),
+        const Icon(AppIcons.menuBook),
         const SizedBox(width: 12),
         Expanded(
           child: DropdownButton<int>(
@@ -359,7 +360,7 @@ class _ActionList extends ConsumerWidget {
           };
 
           return _InfoCard(
-            icon: Icons.checklist_rtl,
+            icon: AppIcons.checklistRtl,
             message: message,
           );
         }
@@ -375,7 +376,7 @@ class _ActionList extends ConsumerWidget {
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, _) => _InfoCard(
-        icon: Icons.error_outline,
+        icon: AppIcons.error,
         message: 'アクションの読み込み中にエラーが発生しました\n$error',
       ),
     );
@@ -488,7 +489,7 @@ class _ActionTile extends ConsumerWidget {
                         children: [
                           Chip(
                             avatar: Icon(
-                              isDone ? Icons.check_circle : Icons.timelapse,
+                              isDone ? AppIcons.checkCircle : AppIcons.timelapse,
                               color: isDone
                                   ? theme.colorScheme.primary
                                   : theme.colorScheme.secondary,
@@ -499,7 +500,7 @@ class _ActionTile extends ConsumerWidget {
                           ),
                           if (action.dueDate != null)
                             InputChip(
-                              avatar: const Icon(Icons.event),
+                              avatar: const Icon(AppIcons.calendar),
                               label: Text(
                                   _formatDueDate(context, action.dueDate!)),
                               backgroundColor:
@@ -507,7 +508,7 @@ class _ActionTile extends ConsumerWidget {
                             ),
                           if (action.remindAt != null)
                             InputChip(
-                              avatar: const Icon(Icons.alarm),
+                              avatar: const Icon(AppIcons.alarm),
                               label: Text(
                                   _formatDueDate(context, action.remindAt!)),
                               backgroundColor: isReminderDue
@@ -516,7 +517,7 @@ class _ActionTile extends ConsumerWidget {
                             ),
                           if (isLinkedToNote)
                             InputChip(
-                              avatar: const Icon(Icons.note_alt_outlined),
+                              avatar: const Icon(AppIcons.note),
                               label: Text(
                                 note.content,
                                 maxLines: 1,
@@ -538,7 +539,7 @@ class _ActionTile extends ConsumerWidget {
               children: [
                 if (!isDone)
                   FilledButton.icon(
-                    icon: const Icon(Icons.check_circle_outline),
+                    icon: const Icon(AppIcons.checkCircleOutline),
                     label: const Text('完了'),
                     onPressed: () => ref
                         .read(actionPlansNotifierProvider.notifier)
@@ -546,21 +547,21 @@ class _ActionTile extends ConsumerWidget {
                   )
                 else
                   OutlinedButton.icon(
-                    icon: const Icon(Icons.refresh),
+                    icon: const Icon(AppIcons.refresh),
                     label: const Text('未完了に戻す'),
                     onPressed: () => ref
                         .read(actionPlansNotifierProvider.notifier)
                         .toggleStatus(action, false),
                   ),
                 TextButton.icon(
-                  icon: const Icon(Icons.alarm_add_outlined),
+                  icon: const Icon(AppIcons.addAlarm),
                   label: Text(action.remindAt == null ? 'リマインド設定' : 'リマインド変更'),
                   onPressed: _selectReminder,
                 ),
                 if (action.remindAt != null)
                   IconButton(
                     tooltip: 'リマインドを解除',
-                    icon: const Icon(Icons.alarm_off),
+                    icon: const Icon(AppIcons.alarmOff),
                     onPressed: _clearReminder,
                   ),
               ],
@@ -593,7 +594,7 @@ class _ActionMenu extends ConsumerWidget {
       children: [
         IconButton(
           tooltip: '編集',
-          icon: const Icon(Icons.edit_outlined),
+          icon: const Icon(AppIcons.edit),
           onPressed: action.bookId == null
               ? null
               : () => showActionPlanDialog(
@@ -605,7 +606,7 @@ class _ActionMenu extends ConsumerWidget {
         ),
         IconButton(
           tooltip: '削除',
-          icon: const Icon(Icons.delete_outline),
+          icon: const Icon(AppIcons.deleteOutline),
           onPressed: action.bookId == null
               ? null
               : () => _confirmDelete(context, ref, action),
@@ -718,11 +719,11 @@ Future<void> showActionPlanDialog(
                                 dueDate = null;
                               });
                             },
-                            icon: const Icon(Icons.close),
+                            icon: const Icon(AppIcons.close),
                           ),
                         TextButton.icon(
                           onPressed: pickDate,
-                          icon: const Icon(Icons.event),
+                          icon: const Icon(AppIcons.calendar),
                           label: const Text('期日を選択'),
                         ),
                       ],
@@ -745,11 +746,11 @@ Future<void> showActionPlanDialog(
                                 remindAt = null;
                               });
                             },
-                            icon: const Icon(Icons.alarm_off),
+                            icon: const Icon(AppIcons.alarmOff),
                           ),
                         TextButton.icon(
                           onPressed: pickReminderDate,
-                          icon: const Icon(Icons.alarm),
+                          icon: const Icon(AppIcons.alarm),
                           label: const Text('リマインド'),
                         ),
                       ],

--- a/lib/features/auth/login_page.dart
+++ b/lib/features/auth/login_page.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/providers/auth_providers.dart';
 import '../../shared/constants/app_constants.dart';
+import '../../shared/constants/app_icons.dart';
 import '../../shared/widgets/app_button.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
@@ -112,11 +113,11 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                       label: 'Magic Linkを送信',
                       expand: true,
                     ),
-                    TextButton.icon(
-                      onPressed: _sendMagicLink,
-                      icon: const Icon(Icons.refresh),
-                      label: const Text('再送'),
-                    ),
+                  TextButton.icon(
+                    onPressed: _sendMagicLink,
+                    icon: const Icon(AppIcons.refresh),
+                    label: const Text('再送'),
+                  ),
                   ],
                 ),
               ),
@@ -142,7 +143,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                   child: Row(
                     children: [
                       Icon(
-                        Icons.mail_outline,
+                        AppIcons.email,
                         color: Theme.of(context).colorScheme.secondary,
                       ),
                       const SizedBox(width: 12),
@@ -167,7 +168,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                   child: Row(
                     children: [
                       Icon(
-                        Icons.error_outline,
+                        AppIcons.error,
                         color: Theme.of(context).colorScheme.error,
                       ),
                       const SizedBox(width: 12),

--- a/lib/features/auth/signup_page.dart
+++ b/lib/features/auth/signup_page.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../core/providers/auth_providers.dart';
 import '../../shared/constants/app_constants.dart';
+import '../../shared/constants/app_icons.dart';
 import '../../shared/widgets/app_button.dart';
 
 class SignUpPage extends ConsumerStatefulWidget {
@@ -121,7 +122,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                   child: Row(
                     children: [
                       Icon(
-                        Icons.mail_outline,
+                        AppIcons.email,
                         color: Theme.of(context).colorScheme.secondary,
                       ),
                       const SizedBox(width: 12),
@@ -146,7 +147,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                   child: Row(
                     children: [
                       Icon(
-                        Icons.error_outline,
+                        AppIcons.error,
                         color: Theme.of(context).colorScheme.error,
                       ),
                       const SizedBox(width: 12),

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../core/providers/auth_providers.dart';
 import '../../shared/constants/app_constants.dart';
+import '../../shared/constants/app_icons.dart';
 import '../../shared/widgets/app_card.dart';
 
 class HomePage extends ConsumerWidget {
@@ -21,7 +22,7 @@ class HomePage extends ConsumerWidget {
             onPressed: () async {
               await ref.read(authServiceProvider).signOut();
             },
-            icon: const Icon(Icons.logout),
+            icon: const Icon(AppIcons.logout),
           ),
         ],
       ),
@@ -52,7 +53,7 @@ class HomePage extends ConsumerWidget {
                   mainAxisSpacing: 16,
                   children: [
                     _FeatureCard(
-                      icon: Icons.search,
+                      icon: AppIcons.search,
                       title: '書籍検索',
                       description: 'Google Books APIで\n書籍を検索',
                       color: Theme.of(context).colorScheme.primary,
@@ -61,7 +62,7 @@ class HomePage extends ConsumerWidget {
                       },
                     ),
                     _FeatureCard(
-                      icon: Icons.library_books,
+                      icon: AppIcons.books,
                       title: '読書記録',
                       description: '読んだ本を\n管理',
                       color: Theme.of(context).colorScheme.secondary,
@@ -70,7 +71,7 @@ class HomePage extends ConsumerWidget {
                       },
                     ),
                     _FeatureCard(
-                      icon: Icons.note,
+                      icon: AppIcons.memo,
                       title: 'メモ',
                       description: '読書メモを\n作成・管理',
                       color: Theme.of(context).colorScheme.tertiary,
@@ -79,7 +80,7 @@ class HomePage extends ConsumerWidget {
                       },
                     ),
                     _FeatureCard(
-                      icon: Icons.speed,
+                      icon: AppIcons.readingSpeed,
                       title: '読書速度',
                       description: '読書速度を\n測定・記録',
                       color: Theme.of(context).colorScheme.primary,
@@ -88,7 +89,7 @@ class HomePage extends ConsumerWidget {
                       },
                     ),
                     _FeatureCard(
-                      icon: Icons.checklist,
+                      icon: AppIcons.actions,
                       title: 'アクションプラン',
                       description: '読書後の\nアクションを管理',
                       color: Theme.of(context).colorScheme.secondary,
@@ -137,7 +138,7 @@ class _FeatureCard extends StatelessWidget {
             ),
             child: Icon(
               icon,
-              size: 32,
+              size: AppIconSizes.extraLarge,
               color: color,
             ),
           ),

--- a/lib/features/memos/memos_feature.dart
+++ b/lib/features/memos/memos_feature.dart
@@ -5,6 +5,7 @@ import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
 import '../action_plans/action_plans_feature.dart';
+import '../../shared/constants/app_icons.dart';
 import '../../shared/widgets/app_button.dart';
 import '../../shared/widgets/app_card.dart';
 
@@ -155,7 +156,7 @@ class MemosPage extends ConsumerWidget {
       floatingActionButton: state.selectedBookId != null
           ? FloatingActionButton(
               onPressed: () => _showNoteDialog(context, ref),
-              child: const Icon(Icons.add),
+              child: const Icon(AppIcons.add),
             )
           : null,
     );
@@ -175,14 +176,14 @@ class _BookSelector extends ConsumerWidget {
 
     if (state.books.isEmpty) {
       return const _InfoCard(
-        icon: Icons.menu_book,
+        icon: AppIcons.menuBook,
         message: 'まずは本を登録してメモを追加しましょう',
       );
     }
 
     return Row(
       children: [
-        const Icon(Icons.menu_book_outlined),
+        const Icon(AppIcons.menuBook),
         const SizedBox(width: 12),
         Expanded(
           child: DropdownButton<int>(
@@ -223,7 +224,7 @@ class _MemoList extends ConsumerWidget {
       data: (notes) {
         if (notes.isEmpty) {
           return const _InfoCard(
-            icon: Icons.note_alt_outlined,
+            icon: AppIcons.note,
             message: 'この本のメモはまだありません',
           );
         }
@@ -239,7 +240,7 @@ class _MemoList extends ConsumerWidget {
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, _) => _InfoCard(
-        icon: Icons.error_outline,
+        icon: AppIcons.error,
         message: 'メモの読み込み中にエラーが発生しました\n$error',
       ),
     );
@@ -271,7 +272,8 @@ class _MemoCard extends ConsumerWidget {
               children: [
                 Chip(
                   label: Text('p.${note.pageNumber}'),
-                  avatar: const Icon(Icons.bookmark_border, size: 18),
+                  avatar:
+                      const Icon(AppIcons.bookmarkBorder, size: AppIconSizes.small),
                 ),
                 _MemoActions(note: note),
               ],
@@ -311,19 +313,19 @@ class _MemoActions extends ConsumerWidget {
       children: [
         IconButton(
           tooltip: '編集',
-          icon: const Icon(Icons.edit_outlined),
+          icon: const Icon(AppIcons.edit),
           onPressed: selectedBookId == null
               ? null
               : () => _showNoteDialog(context, ref, note: note),
         ),
         IconButton(
           tooltip: 'アクションを作成',
-          icon: const Icon(Icons.checklist_outlined),
+          icon: const Icon(AppIcons.checklist),
           onPressed: () => _showActionFromNoteDialog(context, ref, note),
         ),
         IconButton(
           tooltip: '削除',
-          icon: const Icon(Icons.delete_outline),
+          icon: const Icon(AppIcons.deleteOutline),
           onPressed: selectedBookId == null
               ? null
               : () => _confirmDelete(context, ref, noteId: note.id),

--- a/lib/features/reading_speed/reading_speed_feature.dart
+++ b/lib/features/reading_speed/reading_speed_feature.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
+import '../../shared/constants/app_icons.dart';
 
 final readingSpeedNotifierProvider =
     StateNotifierProvider<ReadingSpeedNotifier, ReadingSpeedState>((ref) {
@@ -292,7 +293,7 @@ class _SummarySection extends StatelessWidget {
           child: _SummaryCard(
             title: '今日',
             value: '${state.dailyTotal} ページ',
-            icon: Icons.today,
+            icon: AppIcons.today,
             color: Colors.blue,
           ),
         ),
@@ -301,7 +302,7 @@ class _SummarySection extends StatelessWidget {
           child: _SummaryCard(
             title: '今週',
             value: '${state.weeklyTotal} ページ',
-            icon: Icons.calendar_view_week,
+            icon: AppIcons.calendarViewWeek,
             color: Colors.green,
           ),
         ),
@@ -310,7 +311,7 @@ class _SummarySection extends StatelessWidget {
           child: _SummaryCard(
             title: '今月',
             value: '${state.monthlyTotal} ページ',
-            icon: Icons.calendar_month,
+            icon: AppIcons.calendarMonth,
             color: Colors.purple,
           ),
         ),
@@ -379,7 +380,7 @@ class _ReadingLogForm extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     if (state.books.isEmpty) {
       return const _InfoCard(
-        icon: Icons.menu_book_outlined,
+        icon: AppIcons.menuBook,
         message: 'まずは検索から本を登録して読書ログを追加しましょう',
       );
     }
@@ -440,7 +441,7 @@ class _ReadingLogForm extends ConsumerWidget {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton.icon(
-                icon: const Icon(Icons.save_alt),
+                icon: const Icon(AppIcons.saveAlt),
                 label: const Text('記録する'),
                 onPressed: () => _submit(context, ref),
               ),
@@ -508,7 +509,7 @@ class _ReadingChart extends StatelessWidget {
             const SizedBox(height: 12),
             if (points.isEmpty)
               const _InfoCard(
-                icon: Icons.bar_chart,
+                icon: AppIcons.barChart,
                 message: 'まだ読書ログがありません',
               )
             else
@@ -561,7 +562,7 @@ class _ReadingLogList extends StatelessWidget {
   Widget build(BuildContext context) {
     if (logs.isEmpty) {
       return const _InfoCard(
-        icon: Icons.book_outlined,
+        icon: AppIcons.book,
         message: '記録はまだありません。ページ数を入力して記録しましょう。',
       );
     }
@@ -609,7 +610,7 @@ class _InfoCard extends StatelessWidget {
         padding: const EdgeInsets.all(12),
         child: Row(
           children: [
-            Icon(icon, size: 28),
+            Icon(icon, size: AppIconSizes.large),
             const SizedBox(width: 12),
             Expanded(
               child: Text(
@@ -639,7 +640,7 @@ class _ErrorCard extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Icon(Icons.error_outline, color: Colors.red),
+              const Icon(AppIcons.error, color: Colors.red),
               const SizedBox(height: 8),
               Text(
                 '読み込みに失敗しました',

--- a/lib/features/search/search_feature.dart
+++ b/lib/features/search/search_feature.dart
@@ -10,6 +10,7 @@ import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
 import '../../core/services/google_books_api_client.dart';
 import '../../core/models/google_books/google_books_volume.dart';
+import '../../shared/constants/app_icons.dart';
 import '../../shared/widgets/app_button.dart';
 import '../../shared/widgets/app_card.dart';
 
@@ -281,7 +282,7 @@ class _OnlineSearchTabState extends ConsumerState<_OnlineSearchTab> {
                 decoration: const InputDecoration(
                   labelText: 'キーワード',
                   hintText: 'タイトルや著者名を入力（例: Effective Dart、村上春樹）',
-                  prefixIcon: Icon(Icons.search),
+                  prefixIcon: Icon(AppIcons.search),
                 ),
                 textInputAction: TextInputAction.search,
                 onSubmitted: (_) => _triggerSearch(),
@@ -289,7 +290,7 @@ class _OnlineSearchTabState extends ConsumerState<_OnlineSearchTab> {
               const SizedBox(height: 16),
               AppButton.primary(
                 onPressed: _triggerSearch,
-                icon: Icons.search,
+                icon: AppIcons.search,
                 label: '検索する',
                 expand: true,
               ),
@@ -353,7 +354,7 @@ class _LocalSearchTabState extends ConsumerState<_LocalSearchTab> {
                 decoration: const InputDecoration(
                   labelText: 'キーワード',
                   hintText: 'タイトル / 著者 / メモ内容 で検索',
-                  prefixIcon: Icon(Icons.search),
+                  prefixIcon: Icon(AppIcons.search),
                 ),
                 textInputAction: TextInputAction.search,
                 onSubmitted: (_) => _triggerSearch(),
@@ -361,7 +362,7 @@ class _LocalSearchTabState extends ConsumerState<_LocalSearchTab> {
               const SizedBox(height: 12),
               Row(
                 children: [
-                  const Icon(Icons.filter_alt_outlined),
+                  const Icon(AppIcons.filter),
                   const SizedBox(width: 8),
                   Expanded(
                     child: DropdownButton<BookStatus?>(
@@ -392,7 +393,7 @@ class _LocalSearchTabState extends ConsumerState<_LocalSearchTab> {
               const SizedBox(height: 12),
               AppButton.primary(
                 onPressed: _triggerSearch,
-                icon: Icons.manage_search,
+                icon: AppIcons.manageSearch,
                 label: 'ローカルを検索',
                 expand: true,
               ),
@@ -623,9 +624,9 @@ class _BookListTile extends StatelessWidget {
                     ),
                   ),
               ],
+              ),
             ),
-          ),
-          const Icon(Icons.chevron_right),
+          const Icon(AppIcons.chevronRight),
         ],
       ),
     );
@@ -644,7 +645,7 @@ class _BookThumbnail extends StatelessWidget {
       height: 90,
       child: ColoredBox(
         color: Color(0xFFE0E0E0),
-        child: Icon(Icons.menu_book),
+        child: Icon(AppIcons.menuBook),
       ),
     );
 
@@ -685,12 +686,16 @@ class _ErrorView extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.error_outline, size: 48, color: Colors.redAccent),
-            const SizedBox(height: 12),
-            const Text('検索中にエラーが発生しました'),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+            const Icon(
+              AppIcons.error,
+              size: AppIconSizes.extraLarge,
+              color: Colors.redAccent,
+            ),
+              const SizedBox(height: 12),
+              const Text('検索中にエラーが発生しました'),
             const SizedBox(height: 8),
             Text(
               error.toString(),
@@ -1015,7 +1020,8 @@ class _BookRegistrationCard extends StatelessWidget {
               if (isRegistered)
                 Chip(
                   label: Text('登録済み'),
-                  avatar: const Icon(Icons.check, size: 18),
+                  avatar:
+                      const Icon(AppIcons.check, size: AppIconSizes.small),
                 ),
             ],
           ),
@@ -1042,7 +1048,7 @@ class _BookRegistrationCard extends StatelessWidget {
           const SizedBox(height: 16),
           AppButton.primary(
             onPressed: onSave,
-            icon: isRegistered ? Icons.save : Icons.library_add,
+            icon: isRegistered ? AppIcons.save : AppIcons.addLibrary,
             label: isRegistered ? 'ステータスを更新' : '本を登録',
             expand: true,
           ),
@@ -1131,7 +1137,7 @@ class _DatePickerRow extends StatelessWidget {
               const SizedBox(height: 8),
               OutlinedButton.icon(
                 onPressed: onTap,
-                icon: const Icon(Icons.calendar_today),
+                icon: const Icon(AppIcons.calendar),
                 label: Text(displayDate),
               ),
             ],
@@ -1142,7 +1148,7 @@ class _DatePickerRow extends StatelessWidget {
           IconButton(
             tooltip: 'クリア',
             onPressed: onClear,
-            icon: const Icon(Icons.close),
+            icon: const Icon(AppIcons.close),
           ),
         ]
       ],

--- a/lib/shared/constants/app_icons.dart
+++ b/lib/shared/constants/app_icons.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+
+class AppIcons {
+  static const IconData search = SymbolsRounded.search;
+  static const IconData books = SymbolsRounded.auto_stories;
+  static const IconData memo = SymbolsRounded.note_stack;
+  static const IconData readingSpeed = SymbolsRounded.speed;
+  static const IconData actions = SymbolsRounded.checklist;
+  static const IconData logout = SymbolsRounded.logout;
+  static const IconData calendar = SymbolsRounded.calendar_month;
+  static const IconData refresh = SymbolsRounded.refresh;
+  static const IconData email = SymbolsRounded.mail;
+  static const IconData error = SymbolsRounded.error_circle_rounded;
+  static const IconData add = SymbolsRounded.add;
+  static const IconData addTask = SymbolsRounded.add_task;
+  static const IconData addAlarm = SymbolsRounded.alarm_add;
+  static const IconData alarmOff = SymbolsRounded.alarm_off;
+  static const IconData alarm = SymbolsRounded.alarm_on;
+  static const IconData timelapse = SymbolsRounded.timelapse;
+  static const IconData checklist = SymbolsRounded.checklist;
+  static const IconData checklistRtl = SymbolsRounded.checklist_rtl;
+  static const IconData menuBook = SymbolsRounded.menu_book;
+  static const IconData note = SymbolsRounded.note_alt;
+  static const IconData delete = SymbolsRounded.delete;
+  static const IconData deleteOutline = SymbolsRounded.delete_outline;
+  static const IconData edit = SymbolsRounded.edit;
+  static const IconData checkCircle = SymbolsRounded.check_circle;
+  static const IconData checkCircleOutline = SymbolsRounded.check_circle;
+  static const IconData close = SymbolsRounded.close;
+  static const IconData chevronRight = SymbolsRounded.chevron_right;
+  static const IconData saveAlt = SymbolsRounded.save;
+  static const IconData barChart = SymbolsRounded.bar_chart_4_bars;
+  static const IconData book = SymbolsRounded.menu_book;
+  static const IconData bookmark = SymbolsRounded.bookmark;
+  static const IconData bookmarkBorder = SymbolsRounded.bookmark_add;
+  static const IconData save = SymbolsRounded.save;
+  static const IconData addLibrary = SymbolsRounded.library_add;
+  static const IconData check = SymbolsRounded.check;
+  static const IconData noteAlt = SymbolsRounded.note_alt;
+  static const IconData settings = SymbolsRounded.settings;
+  static const IconData filter = SymbolsRounded.filter_alt;
+  static const IconData manageSearch = SymbolsRounded.manage_search;
+  static const IconData today = SymbolsRounded.today;
+  static const IconData calendarViewWeek = SymbolsRounded.calendar_view_week;
+  static const IconData calendarMonth = SymbolsRounded.calendar_month;
+  static const IconData speed = SymbolsRounded.speed;
+}
+
+class AppIconSizes {
+  static const double small = 20;
+  static const double medium = 24;
+  static const double large = 28;
+  static const double extraLarge = 32;
+}

--- a/lib/shared/widgets/app_button.dart
+++ b/lib/shared/widgets/app_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../constants/app_icons.dart';
+
 class AppButton extends StatelessWidget {
   const AppButton.primary({
     super.key,
@@ -26,8 +28,8 @@ class AppButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final child = switch (variant) {
-      _ButtonVariant.primary => _buildFilledButton(),
-      _ButtonVariant.secondary => _buildOutlinedButton(),
+      _ButtonVariant.primary => _buildFilledButton(context),
+      _ButtonVariant.secondary => _buildOutlinedButton(context),
     };
 
     if (expand) {
@@ -37,11 +39,15 @@ class AppButton extends StatelessWidget {
     return child;
   }
 
-  Widget _buildFilledButton() {
+  Widget _buildFilledButton(BuildContext context) {
     if (icon != null) {
       return ElevatedButton.icon(
         onPressed: onPressed,
-        icon: Icon(icon),
+        icon: Icon(
+          icon,
+          size: AppIconSizes.medium,
+          color: Theme.of(context).colorScheme.onPrimary,
+        ),
         label: Text(label),
       );
     }
@@ -52,11 +58,15 @@ class AppButton extends StatelessWidget {
     );
   }
 
-  Widget _buildOutlinedButton() {
+  Widget _buildOutlinedButton(BuildContext context) {
     if (icon != null) {
       return OutlinedButton.icon(
         onPressed: onPressed,
-        icon: Icon(icon),
+        icon: Icon(
+          icon,
+          size: AppIconSizes.medium,
+          color: Theme.of(context).colorScheme.primary,
+        ),
         label: Text(label),
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   flex_color_scheme: ^7.3.1
   google_fonts: ^6.2.1
 
+  # Icons
+  material_symbols_icons: ^4.2801.0
+
   # State Management
   flutter_riverpod: ^2.5.1
   hooks_riverpod: ^2.5.1


### PR DESCRIPTION
## Summary
- add the material_symbols_icons dependency and centralize rounded icon choices/sizing in a shared constants file
- align app icon theming with primary/onPrimary colors via updated icon themes and shared button icon styling
- replace legacy Icons usages across auth, home, search, memos, action plans, and reading speed flows with Material Symbols Rounded equivalents for consistent design

## Testing
- Not run (Flutter tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226e1e441c832980416a797d8a8219)