### PR TITLE
Add Supabase-backed profile settings and avatar upload

### DIFF
--- a/lib/core/models/profile.dart
+++ b/lib/core/models/profile.dart
@@ -1,0 +1,79 @@
+import 'package:collection/collection.dart';
+
+class UserProfile {
+  const UserProfile({
+    required this.userId,
+    required this.name,
+    this.bio,
+    this.avatarUrl,
+    this.readingThemes = const [],
+  });
+
+  factory UserProfile.fromMap(Map<String, dynamic> map) {
+    final themes = map['reading_themes'];
+    return UserProfile(
+      userId: map['user_id'] as String,
+      name: map['name'] as String? ?? '',
+      bio: map['bio'] as String?,
+      avatarUrl: map['avatar_url'] as String?,
+      readingThemes: themes == null
+          ? const []
+          : (themes as List<dynamic>)
+              .whereType<String>()
+              .where((theme) => theme.trim().isNotEmpty)
+              .toList(),
+    );
+  }
+
+  final String userId;
+  final String name;
+  final String? bio;
+  final String? avatarUrl;
+  final List<String> readingThemes;
+
+  Map<String, dynamic> toMap() {
+    return {
+      'user_id': userId,
+      'name': name,
+      'bio': bio,
+      'avatar_url': avatarUrl,
+      'reading_themes': readingThemes,
+    };
+  }
+
+  UserProfile copyWith({
+    String? userId,
+    String? name,
+    String? bio,
+    String? avatarUrl,
+    List<String>? readingThemes,
+  }) {
+    return UserProfile(
+      userId: userId ?? this.userId,
+      name: name ?? this.name,
+      bio: bio ?? this.bio,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      readingThemes: readingThemes ?? this.readingThemes,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is UserProfile &&
+        other.userId == userId &&
+        other.name == name &&
+        other.bio == bio &&
+        other.avatarUrl == avatarUrl &&
+        const ListEquality<String>().equals(other.readingThemes, readingThemes);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        userId,
+        name,
+        bio,
+        avatarUrl,
+        const ListEquality<String>().hash(readingThemes),
+      );
+}

--- a/lib/core/providers/profile_providers.dart
+++ b/lib/core/providers/profile_providers.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../models/profile.dart';
+import '../services/profile_service.dart';
+import '../services/supabase_service.dart';
+import 'auth_providers.dart';
+
+final profileServiceProvider = Provider<ProfileService?>((ref) {
+  final supabase = ref.watch(supabaseServiceProvider);
+  if (supabase == null) {
+    return null;
+  }
+  return ProfileService(client: supabase.client);
+});
+
+class ProfileState {
+  const ProfileState({
+    this.profile,
+    this.isLoading = true,
+    this.isSaving = false,
+    this.errorMessage,
+  });
+
+  final UserProfile? profile;
+  final bool isLoading;
+  final bool isSaving;
+  final String? errorMessage;
+
+  ProfileState copyWith({
+    UserProfile? profile,
+    bool? isLoading,
+    bool? isSaving,
+    String? errorMessage,
+  }) {
+    return ProfileState(
+      profile: profile ?? this.profile,
+      isLoading: isLoading ?? this.isLoading,
+      isSaving: isSaving ?? this.isSaving,
+      errorMessage: errorMessage,
+    );
+  }
+}
+
+class ProfileNotifier extends StateNotifier<ProfileState> {
+  ProfileNotifier(this._ref) : super(const ProfileState()) {
+    _loadProfile();
+  }
+
+  final Ref _ref;
+
+  ProfileService? get _service => _ref.read(profileServiceProvider);
+  String? get _userId => _ref.read(currentUserIdProvider);
+
+  Future<void> _loadProfile() async {
+    final service = _service;
+    final userId = _userId;
+
+    if (service == null || userId == null) {
+      state = state.copyWith(isLoading: false);
+      return;
+    }
+
+    state = state.copyWith(isLoading: true, errorMessage: null);
+
+    try {
+      final profile = await service.fetchProfile(userId);
+      state = state.copyWith(
+        profile: profile ?? UserProfile(userId: userId, name: ''),
+        isLoading: false,
+      );
+    } catch (error, stackTrace) {
+      debugPrint('Failed to load profile: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          context: ErrorDescription('Failed to load profile'),
+        ),
+      );
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'プロフィールの読み込みに失敗しました。',
+      );
+    }
+  }
+
+  Future<bool> saveProfile({
+    required String name,
+    String? bio,
+    required List<String> readingThemes,
+  }) async {
+    final service = _service;
+    final userId = _userId;
+
+    if (service == null || userId == null) {
+      state = state.copyWith(
+        errorMessage: 'プロフィール機能を使用するにはSupabaseの設定が必要です。',
+      );
+      return false;
+    }
+
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      final profile = (state.profile ??
+              UserProfile(userId: userId, name: name, bio: bio))
+          .copyWith(
+        name: name,
+        bio: bio,
+        readingThemes: readingThemes,
+      );
+
+      final saved = await service.upsertProfile(profile);
+      state = state.copyWith(profile: saved, isSaving: false);
+      return true;
+    } catch (error, stackTrace) {
+      debugPrint('Failed to save profile: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          context: ErrorDescription('Failed to save profile'),
+        ),
+      );
+      state = state.copyWith(
+        isSaving: false,
+        errorMessage: 'プロフィールの保存に失敗しました。',
+      );
+      return false;
+    }
+  }
+
+  Future<bool> uploadAvatar(XFile file) async {
+    final service = _service;
+    final userId = _userId;
+
+    if (service == null || userId == null) {
+      state = state.copyWith(
+        errorMessage: 'プロフィール機能を使用するにはSupabaseの設定が必要です。',
+      );
+      return false;
+    }
+
+    state = state.copyWith(isSaving: true, errorMessage: null);
+    try {
+      final bytes = await file.readAsBytes();
+      final url = await service.uploadAvatar(
+        userId: userId,
+        fileBytes: bytes,
+        fileName: file.name,
+      );
+
+      final updatedProfile = (state.profile ??
+              UserProfile(userId: userId, name: '', avatarUrl: url))
+          .copyWith(avatarUrl: url);
+
+      state = state.copyWith(profile: updatedProfile, isSaving: false);
+      return true;
+    } catch (error, stackTrace) {
+      debugPrint('Failed to upload avatar: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          context: ErrorDescription('Failed to upload avatar'),
+        ),
+      );
+      state = state.copyWith(
+        isSaving: false,
+        errorMessage: 'アバターのアップロードに失敗しました。',
+      );
+      return false;
+    }
+  }
+
+  void reload() {
+    _loadProfile();
+  }
+
+  void handleUserChanged() {
+    state = const ProfileState();
+    _loadProfile();
+  }
+}
+
+final profileNotifierProvider =
+    StateNotifierProvider<ProfileNotifier, ProfileState>((ref) {
+  final notifier = ProfileNotifier(ref);
+
+  ref.listen<String?>(currentUserIdProvider, (previous, next) {
+    if (previous != next) {
+      notifier.handleUserChanged();
+    }
+  });
+
+  return notifier;
+});

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -9,6 +9,7 @@ import '../../features/home/home_feature.dart';
 import '../../features/memos/memos_feature.dart';
 import '../../features/reading_speed/reading_speed_feature.dart';
 import '../../features/search/search_feature.dart';
+import '../../features/profile/profile_feature.dart';
 import '../providers/auth_providers.dart';
 import '../services/auth_service.dart';
 
@@ -101,6 +102,10 @@ final appRouterProvider = StateProvider<GoRouter>((ref) {
       GoRoute(
         path: '/reading-speed',
         builder: (context, state) => const ReadingSpeedPage(),
+      ),
+      GoRoute(
+        path: '/profile',
+        builder: (context, state) => const ProfilePage(),
       ),
     ],
   );

--- a/lib/core/services/profile_service.dart
+++ b/lib/core/services/profile_service.dart
@@ -1,0 +1,67 @@
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as path;
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/profile.dart';
+
+class ProfileService {
+  ProfileService({required SupabaseClient client}) : _client = client;
+
+  static const _profilesTable = 'profiles';
+  static const _avatarsBucket = 'avatars';
+
+  final SupabaseClient _client;
+
+  Future<UserProfile?> fetchProfile(String userId) async {
+    final response = await _client
+        .from(_profilesTable)
+        .select()
+        .eq('user_id', userId)
+        .maybeSingle();
+
+    if (response == null) {
+      return null;
+    }
+
+    return UserProfile.fromMap(response);
+  }
+
+  Future<UserProfile> upsertProfile(UserProfile profile) async {
+    final response = await _client
+        .from(_profilesTable)
+        .upsert(profile.toMap())
+        .select()
+        .single();
+
+    return UserProfile.fromMap(response);
+  }
+
+  Future<String> uploadAvatar({
+    required String userId,
+    required Uint8List fileBytes,
+    String? fileName,
+    String? mimeType,
+  }) async {
+    final extension = path.extension(fileName ?? '').replaceFirst('.', '');
+    final safeExtension = extension.isEmpty ? 'jpg' : extension;
+    final objectName =
+        '$userId/${DateTime.now().millisecondsSinceEpoch}.$safeExtension';
+
+    await _client.storage.from(_avatarsBucket).uploadBinary(
+          objectName,
+          fileBytes,
+          fileOptions: FileOptions(
+            cacheControl: '3600',
+            upsert: true,
+            contentType: mimeType ?? 'image/$safeExtension',
+          ),
+        );
+
+    final publicUrl =
+        _client.storage.from(_avatarsBucket).getPublicUrl(objectName);
+    debugPrint('Uploaded avatar to $publicUrl');
+    return publicUrl;
+  }
+}

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../core/providers/auth_providers.dart';
+import '../../core/providers/profile_providers.dart';
 import '../../core/widgets/app_card.dart';
 import '../../core/widgets/app_page.dart';
 import '../../shared/constants/app_constants.dart';
@@ -16,6 +17,13 @@ class HomePage extends ConsumerWidget {
     return AppPage(
       title: AppConstants.appName,
       actions: [
+        IconButton(
+          tooltip: '設定',
+          onPressed: () {
+            context.push('/profile');
+          },
+          icon: const Icon(AppIcons.settings),
+        ),
         IconButton(
           tooltip: 'ログアウト',
           onPressed: () async {
@@ -44,6 +52,8 @@ class HomePage extends ConsumerWidget {
                 .bodyLarge
                 ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
           ),
+          const SizedBox(height: 16),
+          const _ProfileSummaryCard(),
           const SizedBox(height: 32),
           Expanded(
             child: GridView.count(
@@ -153,6 +163,88 @@ class _FeatureCard extends StatelessWidget {
                 .bodySmall
                 ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
             textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileSummaryCard extends ConsumerWidget {
+  const _ProfileSummaryCard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileState = ref.watch(profileNotifierProvider);
+    final profileService = ref.watch(profileServiceProvider);
+
+    if (profileService == null) {
+      return const SizedBox.shrink();
+    }
+
+    final profile = profileState.profile;
+
+    return AppCard(
+      onTap: () => context.push('/profile'),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 28,
+            backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+            backgroundImage:
+                profile?.avatarUrl != null ? NetworkImage(profile!.avatarUrl!) : null,
+            child: profile?.avatarUrl == null
+                ? const Icon(AppIcons.accountCircle)
+                : null,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        profile?.name.isNotEmpty == true
+                            ? profile!.name
+                            : 'プロフィールを設定しましょう',
+                        style: Theme.of(context).textTheme.titleMedium,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const Icon(AppIcons.chevronRight),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  profile?.bio?.isNotEmpty == true
+                      ? profile!.bio!
+                      : '名前や一言、読書テーマを編集できます。',
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (profile != null && profile.readingThemes.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 6,
+                    children: profile.readingThemes
+                        .map(
+                          (theme) => Chip(
+                            label: Text(theme),
+                            visualDensity: VisualDensity.compact,
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ],
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/features/profile/profile_feature.dart
+++ b/lib/features/profile/profile_feature.dart
@@ -1,0 +1,362 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../core/models/profile.dart';
+import '../../core/providers/profile_providers.dart';
+import '../../core/widgets/app_card.dart';
+import '../../core/widgets/app_page.dart';
+import '../../core/widgets/common_button.dart';
+import '../../core/widgets/loading_indicator.dart';
+import '../../shared/constants/app_icons.dart';
+
+class ProfilePage extends ConsumerStatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  ConsumerState<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends ConsumerState<ProfilePage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _bioController = TextEditingController();
+  final _themeController = TextEditingController();
+  List<String> _readingThemes = [];
+  ProviderSubscription<UserProfile?>? _profileSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _profileSubscription = ref.listen(
+      profileNotifierProvider.select((value) => value.profile),
+      (previous, next) {
+        if (previous != next) {
+          _applyProfile(next);
+        }
+      },
+    );
+    final profile = ref.read(profileNotifierProvider).profile;
+    _applyProfile(profile);
+  }
+
+  @override
+  void dispose() {
+    _profileSubscription?.close();
+    _nameController.dispose();
+    _bioController.dispose();
+    _themeController.dispose();
+    super.dispose();
+  }
+
+  void _applyProfile(UserProfile? profile) {
+    if (profile == null) {
+      return;
+    }
+    _nameController.text = profile.name;
+    _bioController.text = profile.bio ?? '';
+    setState(() {
+      _readingThemes = [...profile.readingThemes];
+    });
+  }
+
+  void _addTheme(String value) {
+    final theme = value.trim();
+    if (theme.isEmpty) {
+      return;
+    }
+    setState(() {
+      if (!_readingThemes.contains(theme)) {
+        _readingThemes = [..._readingThemes, theme];
+      }
+    });
+    _themeController.clear();
+  }
+
+  Future<void> _saveProfile() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    final notifier = ref.read(profileNotifierProvider.notifier);
+    final success = await notifier.saveProfile(
+      name: _nameController.text.trim(),
+      bio: _bioController.text.trim().isEmpty
+          ? null
+          : _bioController.text.trim(),
+      readingThemes: _readingThemes,
+    );
+
+    if (!mounted) {
+      return;
+    }
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('プロフィールを保存しました')),
+      );
+      context.pop();
+    } else {
+      final message = ref.read(profileNotifierProvider).errorMessage;
+      if (message != null) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(message)));
+      }
+    }
+  }
+
+  Future<void> _pickAvatar() async {
+    final picker = ImagePicker();
+    final file = await picker.pickImage(source: ImageSource.gallery);
+
+    if (file == null) {
+      return;
+    }
+
+    final notifier = ref.read(profileNotifierProvider.notifier);
+    final success = await notifier.uploadAvatar(file);
+
+    if (!mounted) {
+      return;
+    }
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('アバターを更新しました')),
+      );
+    } else {
+      final message = ref.read(profileNotifierProvider).errorMessage;
+      if (message != null) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(message)));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(profileNotifierProvider.select((value) => value.profile),
+        (previous, next) {
+      if (previous != next) {
+        _applyProfile(next);
+      }
+    });
+
+    final state = ref.watch(profileNotifierProvider);
+    final canUseProfile =
+        ref.watch(profileServiceProvider) != null && state.isLoading == false;
+
+    return AppPage(
+      title: 'プロフィール設定',
+      padding: const EdgeInsets.all(16),
+      actions: [
+        IconButton(
+          onPressed: state.isLoading
+              ? null
+              : () {
+                  ref.read(profileNotifierProvider.notifier).reload();
+                },
+          icon: const Icon(AppIcons.refresh),
+          tooltip: '再読み込み',
+        ),
+      ],
+      child: state.isLoading
+          ? const Center(child: LoadingIndicator())
+          : !canUseProfile
+              ? const _ProfileUnavailable()
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _ProfileHeader(
+                      profile: state.profile,
+                      isSaving: state.isSaving,
+                      onChangeAvatar: _pickAvatar,
+                    ),
+                    const SizedBox(height: 16),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Form(
+                          key: _formKey,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              TextFormField(
+                                controller: _nameController,
+                                decoration: const InputDecoration(
+                                  labelText: '名前',
+                                  hintText: '表示したい名前を入力',
+                                ),
+                                validator: (value) {
+                                  if (value == null || value.trim().isEmpty) {
+                                    return '名前は必須です';
+                                  }
+                                  return null;
+                                },
+                              ),
+                              const SizedBox(height: 16),
+                              TextFormField(
+                                controller: _bioController,
+                                decoration: const InputDecoration(
+                                  labelText: '一言メッセージ',
+                                  hintText: '自己紹介や読書の一言',
+                                ),
+                                maxLines: 2,
+                              ),
+                              const SizedBox(height: 16),
+                              Text(
+                                '読書テーマ',
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                              const SizedBox(height: 8),
+                              Wrap(
+                                spacing: 8,
+                                runSpacing: 8,
+                                children: [
+                                  ..._readingThemes.map(
+                                    (theme) => InputChip(
+                                      label: Text(theme),
+                                      onDeleted: () {
+                                        setState(() {
+                                          _readingThemes = _readingThemes
+                                              .where((item) => item != theme)
+                                              .toList();
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                  SizedBox(
+                                    width: 200,
+                                    child: TextField(
+                                      controller: _themeController,
+                                      decoration: const InputDecoration(
+                                        labelText: 'テーマを追加',
+                                        hintText: 'Enterで追加',
+                                      ),
+                                      onSubmitted: _addTheme,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 24),
+                              SizedBox(
+                                width: double.infinity,
+                                child: CommonButton.primary(
+                                  onPressed:
+                                      state.isSaving ? null : () => _saveProfile(),
+                                  icon: AppIcons.save,
+                                  label:
+                                      state.isSaving ? '保存中...' : 'プロフィールを保存',
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+    );
+  }
+}
+
+class _ProfileHeader extends StatelessWidget {
+  const _ProfileHeader({
+    required this.profile,
+    required this.isSaving,
+    required this.onChangeAvatar,
+  });
+
+  final UserProfile? profile;
+  final bool isSaving;
+  final VoidCallback onChangeAvatar;
+
+  @override
+  Widget build(BuildContext context) {
+    final avatarUrl = profile?.avatarUrl;
+    return AppCard(
+      child: Row(
+        children: [
+          Stack(
+            children: [
+              CircleAvatar(
+                radius: 36,
+                backgroundColor:
+                    Theme.of(context).colorScheme.primaryContainer,
+                backgroundImage:
+                    avatarUrl != null ? NetworkImage(avatarUrl) : null,
+                child: avatarUrl == null
+                    ? const Icon(AppIcons.accountCircle, size: 36)
+                    : null,
+              ),
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: IconButton.filled(
+                  onPressed: isSaving ? null : onChangeAvatar,
+                  icon: const Icon(AppIcons.edit, size: 18),
+                  tooltip: 'アバターを変更',
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  profile?.name.isNotEmpty == true
+                      ? profile!.name
+                      : '未設定のユーザー',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  profile?.bio?.isNotEmpty == true
+                      ? profile!.bio!
+                      : 'プロフィールを設定して読書体験をパーソナライズしましょう',
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileUnavailable extends StatelessWidget {
+  const _ProfileUnavailable();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(AppIcons.error, size: 40),
+          const SizedBox(height: 12),
+          Text(
+            'Supabaseの設定が必要です',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'プロフィール機能を利用するにはSupabaseの接続を有効にしてください。',
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/constants/app_icons.dart
+++ b/lib/shared/constants/app_icons.dart
@@ -39,6 +39,7 @@ class AppIcons {
   static const IconData check = SymbolsRounded.check;
   static const IconData noteAlt = SymbolsRounded.note_alt;
   static const IconData settings = SymbolsRounded.settings;
+  static const IconData accountCircle = SymbolsRounded.account_circle;
   static const IconData filter = SymbolsRounded.filter_alt;
   static const IconData manageSearch = SymbolsRounded.manage_search;
   static const IconData today = SymbolsRounded.today;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   # Utilities
   cupertino_icons: ^1.0.6
   shared_preferences: ^2.2.2
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Supabase profile model, provider, and Supabase storage integration for avatars
- build a profile settings page that edits name, bio, reading themes, and uploads avatars
- surface a cached profile summary and settings navigation from the home page

## Testing
- Not run (Flutter SDK unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922832f8dac8329931b08ff3d5b0daa)