### PR TITLE
Refresh app screens with Material 3 navigation and cards

### DIFF
--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -50,6 +50,12 @@ class AppTheme {
           size: AppIconSizes.medium,
           color: lightColorScheme.onPrimary,
         ),
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          elevation: 2,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(18)),
+          ),
+        ),
       );
 
   static ThemeData get darkTheme => FlexThemeData.dark(
@@ -69,6 +75,12 @@ class AppTheme {
         primaryIconTheme: IconThemeData(
           size: AppIconSizes.medium,
           color: darkColorScheme.onPrimary,
+        ),
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          elevation: 2,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(18)),
+          ),
         ),
       );
 }

--- a/lib/core/widgets/app_card.dart
+++ b/lib/core/widgets/app_card.dart
@@ -16,9 +16,18 @@ class AppCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final shape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(18),
+      side: BorderSide(color: colorScheme.outlineVariant.withOpacity(0.6)),
+    );
+
     final card = Card(
-      elevation: 2,
-      color: backgroundColor,
+      elevation: 1,
+      color: backgroundColor ?? colorScheme.surface,
+      shadowColor: colorScheme.shadow.withOpacity(0.08),
+      surfaceTintColor: colorScheme.surfaceTint.withOpacity(0.08),
+      shape: shape,
       clipBehavior: Clip.antiAlias,
       child: Padding(
         padding: padding,
@@ -29,7 +38,7 @@ class AppCard extends StatelessWidget {
     if (onTap != null) {
       return InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: shape.borderRadius,
         child: card,
       );
     }

--- a/lib/core/widgets/app_navigation_bar.dart
+++ b/lib/core/widgets/app_navigation_bar.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../shared/constants/app_icons.dart';
+
+enum AppDestination { home, search, memos, actions, profile }
+
+class AppNavigationBar extends StatelessWidget {
+  const AppNavigationBar({
+    super.key,
+    required this.current,
+  });
+
+  final AppDestination current;
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: current.index,
+      destinations: const [
+        NavigationDestination(
+          icon: Icon(AppIcons.home),
+          selectedIcon: Icon(AppIcons.homeFilled),
+          label: 'ホーム',
+        ),
+        NavigationDestination(
+          icon: Icon(AppIcons.search),
+          selectedIcon: Icon(AppIcons.search),
+          label: '検索',
+        ),
+        NavigationDestination(
+          icon: Icon(AppIcons.memo),
+          selectedIcon: Icon(AppIcons.memo),
+          label: 'メモ',
+        ),
+        NavigationDestination(
+          icon: Icon(AppIcons.actions),
+          selectedIcon: Icon(AppIcons.actions),
+          label: 'アクション',
+        ),
+        NavigationDestination(
+          icon: Icon(AppIcons.person),
+          selectedIcon: Icon(AppIcons.person),
+          label: 'プロフィール',
+        ),
+      ],
+      onDestinationSelected: (index) {
+        final destination = AppDestination.values[index];
+        switch (destination) {
+          case AppDestination.home:
+            context.go('/');
+            break;
+          case AppDestination.search:
+            context.go('/search');
+            break;
+          case AppDestination.memos:
+            context.go('/memos');
+            break;
+          case AppDestination.actions:
+            context.go('/actions');
+            break;
+          case AppDestination.profile:
+            context.go('/profile');
+            break;
+        }
+      },
+    );
+  }
+}

--- a/lib/core/widgets/app_page.dart
+++ b/lib/core/widgets/app_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'app_navigation_bar.dart';
+
 class AppPage extends StatelessWidget {
   const AppPage({
     super.key,
@@ -9,6 +11,7 @@ class AppPage extends StatelessWidget {
     this.padding = const EdgeInsets.all(24),
     this.floatingActionButton,
     this.bottomNavigationBar,
+    this.currentDestination,
     this.scrollable = false,
     this.bottom,
   });
@@ -19,6 +22,7 @@ class AppPage extends StatelessWidget {
   final EdgeInsetsGeometry padding;
   final Widget? floatingActionButton;
   final Widget? bottomNavigationBar;
+  final AppDestination? currentDestination;
   final bool scrollable;
   final PreferredSizeWidget? bottom;
 
@@ -33,6 +37,10 @@ class AppPage extends StatelessWidget {
           : child,
     );
 
+    final navigationBar = currentDestination != null
+        ? AppNavigationBar(current: currentDestination!)
+        : bottomNavigationBar;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
@@ -41,7 +49,7 @@ class AppPage extends StatelessWidget {
         bottom: bottom,
       ),
       floatingActionButton: floatingActionButton,
-      bottomNavigationBar: bottomNavigationBar,
+      bottomNavigationBar: navigationBar,
       body: SafeArea(child: pageBody),
     );
   }

--- a/lib/features/action_plans/action_plans_feature.dart
+++ b/lib/features/action_plans/action_plans_feature.dart
@@ -5,6 +5,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
+import '../../core/widgets/app_navigation_bar.dart';
+import '../../core/widgets/app_page.dart';
 import '../../shared/constants/app_icons.dart';
 
 enum ActionStatusFilter { all, pending, done }
@@ -227,23 +229,18 @@ class ActionPlansPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(actionPlansNotifierProvider);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('アクションプラン'),
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              _BookSelector(state: state),
-              const SizedBox(height: 16),
-              _StatusFilterRow(state: state),
-              const SizedBox(height: 8),
-              Expanded(child: _ActionList(state: state)),
-            ],
-          ),
-        ),
+    return AppPage(
+      title: 'アクションプラン',
+      padding: const EdgeInsets.all(16),
+      currentDestination: AppDestination.actions,
+      child: Column(
+        children: [
+          _BookSelector(state: state),
+          const SizedBox(height: 16),
+          _StatusFilterRow(state: state),
+          const SizedBox(height: 8),
+          Expanded(child: _ActionList(state: state)),
+        ],
       ),
       floatingActionButton: state.selectedBookId != null
           ? FloatingActionButton(

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/providers/auth_providers.dart';
 import '../../core/providers/profile_providers.dart';
 import '../../core/widgets/app_card.dart';
+import '../../core/widgets/app_navigation_bar.dart';
 import '../../core/widgets/app_page.dart';
 import '../../shared/constants/app_constants.dart';
 import '../../shared/constants/app_icons.dart';
@@ -14,6 +15,8 @@ class HomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return AppPage(
       title: AppConstants.appName,
       actions: [
@@ -35,79 +38,84 @@ class HomePage extends ConsumerWidget {
           icon: const Icon(AppIcons.logout),
         ),
       ],
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: 8),
-          Text(
-            'ようこそ',
-            style: Theme.of(context).textTheme.headlineMedium,
-          ),
-          const SizedBox(height: 8),
-          Text(
-            '読書記録とメモを管理しましょう',
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant),
-          ),
-          const SizedBox(height: 16),
-          const _ProfileSummaryCard(),
-          const SizedBox(height: 32),
-          Expanded(
-            child: GridView.count(
+      padding: EdgeInsets.zero,
+      scrollable: true,
+      currentDestination: AppDestination.home,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 8),
+            Text(
+              'ようこそ',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: 6),
+            Text(
+              '読書記録とメモを管理しましょう',
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+            const SizedBox(height: 16),
+            const _ProfileSummaryCard(),
+            const SizedBox(height: 24),
+            Text(
+              'クイックアクセス',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            GridView.count(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
               crossAxisCount: 2,
               crossAxisSpacing: 16,
               mainAxisSpacing: 16,
+              childAspectRatio: 1.15,
               children: [
                 _FeatureCard(
                   icon: AppIcons.search,
                   title: '書籍検索',
                   description: 'Google Books APIで\n書籍を検索',
-                  color: Theme.of(context).colorScheme.primary,
-                  onTap: () {
-                    context.push('/search');
-                  },
+                  color: colorScheme.primary,
+                  onTap: () => context.push('/search'),
                 ),
                 _FeatureCard(
                   icon: AppIcons.books,
                   title: '読書記録',
                   description: '読んだ本を\n管理',
-                  color: Theme.of(context).colorScheme.secondary,
-                  onTap: () {
-                    context.push('/reading-speed');
-                  },
+                  color: colorScheme.secondary,
+                  onTap: () => context.push('/reading-speed'),
                 ),
                 _FeatureCard(
                   icon: AppIcons.memo,
                   title: 'メモ',
                   description: '読書メモを\n作成・管理',
-                  color: Theme.of(context).colorScheme.tertiary,
-                  onTap: () {
-                    context.push('/memos');
-                  },
+                  color: colorScheme.tertiary,
+                  onTap: () => context.push('/memos'),
                 ),
                 _FeatureCard(
                   icon: AppIcons.readingSpeed,
                   title: '読書速度',
                   description: '読書速度を\n測定・記録',
-                  color: Theme.of(context).colorScheme.primary,
-                  onTap: () {
-                    context.push('/reading-speed');
-                  },
+                  color: colorScheme.primary,
+                  onTap: () => context.push('/reading-speed'),
                 ),
                 _FeatureCard(
                   icon: AppIcons.actions,
                   title: 'アクションプラン',
                   description: '読書後の\nアクションを管理',
-                  color: Theme.of(context).colorScheme.secondary,
-                  onTap: () {
-                    context.push('/actions');
-                  },
+                  color: colorScheme.secondary,
+                  onTap: () => context.push('/actions'),
                 ),
               ],
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -132,33 +140,46 @@ class _FeatureCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return AppCard(
       onTap: onTap,
+      padding: const EdgeInsets.all(18),
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: color.withOpacity(0.1),
-              shape: BoxShape.circle,
-            ),
-            child: Icon(
-              icon,
-              size: AppIconSizes.extraLarge,
-              color: color,
-            ),
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: color.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Icon(
+                  icon,
+                  size: AppIconSizes.large,
+                  color: color,
+                ),
+              ),
+              const Spacer(),
+              Icon(
+                AppIcons.chevronRight,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ],
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: 14),
           Text(
             title,
-            style: Theme.of(context).textTheme.titleMedium,
-            textAlign: TextAlign.center,
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(fontWeight: FontWeight.w700),
           ),
-          const SizedBox(height: 4),
+          const SizedBox(height: 6),
           Text(
             description,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant),
-            textAlign: TextAlign.center,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  height: 1.4,
+                ),
           ),
         ],
       ),
@@ -182,10 +203,11 @@ class _ProfileSummaryCard extends ConsumerWidget {
 
     return AppCard(
       onTap: () => context.push('/profile'),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
       child: Row(
         children: [
           CircleAvatar(
-            radius: 28,
+            radius: 30,
             backgroundColor: Theme.of(context).colorScheme.primaryContainer,
             backgroundImage: profile?.avatarUrl != null
                 ? NetworkImage(profile!.avatarUrl!)
@@ -193,7 +215,7 @@ class _ProfileSummaryCard extends ConsumerWidget {
             child:
                 profile?.avatarUrl == null ? const Icon(AppIcons.person) : null,
           ),
-          const SizedBox(width: 12),
+          const SizedBox(width: 14),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -205,7 +227,10 @@ class _ProfileSummaryCard extends ConsumerWidget {
                         profile?.name.isNotEmpty == true
                             ? profile!.name
                             : 'プロフィールを設定しましょう',
-                        style: Theme.of(context).textTheme.titleMedium,
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w700),
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
@@ -218,15 +243,17 @@ class _ProfileSummaryCard extends ConsumerWidget {
                       ? profile!.bio!
                       : '名前や一言、読書テーマを編集できます。',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant),
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
                 if (profile != null && profile.readingThemes.isNotEmpty) ...[
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 10),
                   Wrap(
-                    spacing: 6,
-                    runSpacing: 6,
+                    spacing: 8,
+                    runSpacing: 8,
                     children: profile.readingThemes
                         .map(
                           (theme) => Chip(

--- a/lib/features/memos/memos_feature.dart
+++ b/lib/features/memos/memos_feature.dart
@@ -5,6 +5,7 @@ import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
 import '../../core/widgets/app_card.dart';
+import '../../core/widgets/app_navigation_bar.dart';
 import '../../core/widgets/app_page.dart';
 import '../../core/widgets/common_button.dart';
 import '../../core/widgets/empty_state.dart';
@@ -143,6 +144,7 @@ class MemosPage extends ConsumerWidget {
     return AppPage(
       title: '読書メモ',
       padding: const EdgeInsets.all(16),
+      currentDestination: AppDestination.memos,
       child: Column(
         children: [
           _BookSelector(state: state),
@@ -263,35 +265,45 @@ class _MemoCard extends ConsumerWidget {
     );
 
     return AppCard(
+      padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (note.pageNumber != null) ...[
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (note.pageNumber != null)
                 Chip(
                   label: Text('p.${note.pageNumber}'),
                   avatar:
                       const Icon(AppIcons.bookmarkBorder, size: AppIconSizes.small),
                 ),
-                _MemoActions(note: note),
-              ],
-            ),
-            const SizedBox(height: 8),
-          ] else
-            Align(
-              alignment: Alignment.centerRight,
-              child: _MemoActions(note: note),
-            ),
+              const Spacer(),
+              _MemoActions(note: note),
+            ],
+          ),
+          const SizedBox(height: 8),
           Text(
             note.content,
             style: Theme.of(context).textTheme.bodyLarge,
           ),
           const SizedBox(height: 12),
-          Text(
-            '作成: $createdDate $createdTime',
-            style: Theme.of(context).textTheme.bodySmall,
+          Row(
+            children: [
+              Icon(
+                AppIcons.today,
+                size: AppIconSizes.small,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                '作成: $createdDate $createdTime',
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/features/profile/profile_feature.dart
+++ b/lib/features/profile/profile_feature.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import '../../core/models/profile.dart';
 import '../../core/providers/profile_providers.dart';
 import '../../core/widgets/app_card.dart';
+import '../../core/widgets/app_navigation_bar.dart';
 import '../../core/widgets/app_page.dart';
 import '../../core/widgets/common_button.dart';
 import '../../core/widgets/loading_indicator.dart';
@@ -150,6 +151,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
     return AppPage(
       title: 'プロフィール設定',
       padding: const EdgeInsets.all(16),
+      currentDestination: AppDestination.profile,
       actions: [
         IconButton(
           onPressed: state.isLoading

--- a/lib/features/reading_speed/reading_speed_feature.dart
+++ b/lib/features/reading_speed/reading_speed_feature.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
+import '../../core/widgets/app_card.dart';
 import '../../shared/constants/app_icons.dart';
 
 final readingSpeedNotifierProvider =
@@ -582,13 +583,50 @@ class _ReadingLogList extends StatelessWidget {
           final pages =
               max(0, (entry.log.endPage ?? 0) - (entry.log.startPage ?? 0));
 
-          return Card(
-            child: ListTile(
-              title: Text(entry.book?.title ?? '不明な本'),
-              subtitle: Text('$dateLabel · $pages ページ'),
-              trailing: entry.log.durationMinutes != null
-                  ? Text('${entry.log.durationMinutes} 分')
-                  : null,
+          return AppCard(
+            padding: const EdgeInsets.all(14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        entry.book?.title ?? '不明な本',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleMedium
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                    if (entry.log.durationMinutes != null)
+                      Chip(
+                        label: Text('${entry.log.durationMinutes} 分'),
+                        avatar: const Icon(AppIcons.timelapse,
+                            size: AppIconSizes.small),
+                        visualDensity: VisualDensity.compact,
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      AppIcons.today,
+                      size: AppIconSizes.small,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      '$dateLabel · $pages ページ',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                  ],
+                ),
+              ],
             ),
           );
         }),

--- a/lib/features/search/search_feature.dart
+++ b/lib/features/search/search_feature.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/models/book.dart';
 import '../../core/widgets/app_card.dart';
+import '../../core/widgets/app_navigation_bar.dart';
 import '../../core/widgets/app_page.dart';
 import '../../core/widgets/common_button.dart';
 import '../../core/widgets/empty_state.dart';
@@ -228,6 +229,7 @@ class SearchPage extends StatelessWidget {
       child: AppPage(
         title: '検索',
         padding: EdgeInsets.zero,
+        currentDestination: AppDestination.search,
         bottom: const TabBar(
           tabs: [
             Tab(text: 'オンライン検索'),
@@ -609,46 +611,79 @@ class _BookListTile extends StatelessWidget {
           ),
         );
       },
+      padding: const EdgeInsets.all(14),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _BookThumbnail(url: book.thumbnailUrl),
-          const SizedBox(width: 12),
+          const SizedBox(width: 14),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
                   book.title,
-                  style: Theme.of(context).textTheme.titleMedium,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w700),
                 ),
                 if (book.authors?.isNotEmpty == true)
                   Padding(
-                    padding: const EdgeInsets.only(top: 4),
+                    padding: const EdgeInsets.only(top: 6),
                     child: Text(
                       book.authors!,
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color:
                                 Theme.of(context).colorScheme.onSurfaceVariant,
+                            height: 1.4,
                           ),
                     ),
                   ),
-                if (book.publishedDate != null)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Text(
-                      '出版日: ${book.publishedDate}',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
-                    ),
-                  ),
+                const SizedBox(height: 10),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    if (book.publishedDate != null)
+                      _MetaChip(
+                        icon: AppIcons.calendar,
+                        label: book.publishedDate!,
+                      ),
+                    if (book.pageCount != null)
+                      _MetaChip(
+                        icon: AppIcons.book,
+                        label: '${book.pageCount}ページ',
+                      ),
+                  ],
+                ),
               ],
-              ),
             ),
+          ),
+          const SizedBox(width: 6),
           const Icon(AppIcons.chevronRight),
         ],
       ),
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      visualDensity: VisualDensity.compact,
+      avatar: Icon(icon, size: AppIconSizes.small),
+      label: Text(label),
     );
   }
 }
@@ -819,89 +854,135 @@ class _BookDetailPageState extends ConsumerState<BookDetailPage> {
         title: const Text('書籍詳細'),
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
+        child: ListView(
           padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Center(
-                child: _BookThumbnail(url: widget.book.thumbnailUrl),
+          children: [
+            AppCard(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _BookThumbnail(url: widget.book.thumbnailUrl),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.book.title,
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleLarge
+                              ?.copyWith(fontWeight: FontWeight.w700),
+                        ),
+                        if (widget.book.authors?.isNotEmpty == true) ...[
+                          const SizedBox(height: 8),
+                          Text(
+                            widget.book.authors!,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                                  height: 1.4,
+                                ),
+                          ),
+                        ],
+                        const SizedBox(height: 12),
+                        Wrap(
+                          spacing: 10,
+                          runSpacing: 8,
+                          children: [
+                            if (widget.book.publishedDate != null)
+                              _MetaChip(
+                                icon: AppIcons.calendar,
+                                label: widget.book.publishedDate!,
+                              ),
+                            if (widget.book.pageCount != null)
+                              _MetaChip(
+                                icon: AppIcons.book,
+                                label: '${widget.book.pageCount}ページ',
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: 16),
-              Text(
-                widget.book.title,
-                style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            AppCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '概要',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    widget.book.description ?? '説明がありません',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.copyWith(height: 1.5),
+                  ),
+                ],
               ),
-              if (widget.book.authors?.isNotEmpty == true) ...[
-                const SizedBox(height: 8),
-                Text('著者: ${widget.book.authors}'),
-              ],
-              if (widget.book.publishedDate != null) ...[
-                const SizedBox(height: 8),
-                Text('出版日: ${widget.book.publishedDate}'),
-              ],
-              if (widget.book.pageCount != null) ...[
-                const SizedBox(height: 8),
-                Text('ページ数: ${widget.book.pageCount}'),
-              ],
-              const SizedBox(height: 16),
-              const Text(
-                '概要',
-                style: TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                widget.book.description ?? '説明がありません',
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 24),
-              _ReadingPeriodCard(
-                startedAt: _startedAt,
-                finishedAt: _finishedAt,
-                onTapStartDate: () => _pickDate(isStartDate: true),
-                onTapEndDate: () => _pickDate(isStartDate: false),
-                onClearStartDate: _startedAt != null
-                    ? () {
-                        setState(() {
-                          _startedAt = null;
-                        });
-                      }
-                    : null,
-                onClearEndDate: _finishedAt != null
-                    ? () {
-                        setState(() {
-                          _finishedAt = null;
-                        });
-                      }
-                    : null,
-              ),
-              const SizedBox(height: 24),
-              _BookRegistrationCard(
-                selectedStatus: _selectedStatus ?? widget.book.status,
-                onStatusChanged: (status) {
-                  final now = DateTime.now();
-                  final today = DateTime(now.year, now.month, now.day);
-
-                  setState(() {
-                    _selectedStatus = status;
-
-                    // 読書中になったら、開始日が未設定の場合は今日を設定
-                    if (status == BookStatus.reading && _startedAt == null) {
-                      _startedAt = today;
+            ),
+            const SizedBox(height: 12),
+            _ReadingPeriodCard(
+              startedAt: _startedAt,
+              finishedAt: _finishedAt,
+              onTapStartDate: () => _pickDate(isStartDate: true),
+              onTapEndDate: () => _pickDate(isStartDate: false),
+              onClearStartDate: _startedAt != null
+                  ? () {
+                      setState(() {
+                        _startedAt = null;
+                      });
                     }
-
-                    // 読了になったら、終了日が未設定の場合は今日を設定
-                    if (status == BookStatus.finished && _finishedAt == null) {
-                      _finishedAt = today;
+                  : null,
+              onClearEndDate: _finishedAt != null
+                  ? () {
+                      setState(() {
+                        _finishedAt = null;
+                      });
                     }
-                  });
-                },
-                onSave: () => _handleSave(existingBook),
-                isRegistered: existingBook != null,
-                isLoading: bookRowAsync.isLoading,
-              ),
-            ],
-          ),
+                  : null,
+            ),
+            const SizedBox(height: 12),
+            _BookRegistrationCard(
+              selectedStatus: _selectedStatus ?? widget.book.status,
+              onStatusChanged: (status) {
+                final now = DateTime.now();
+                final today = DateTime(now.year, now.month, now.day);
+
+                setState(() {
+                  _selectedStatus = status;
+
+                  // 読書中になったら、開始日が未設定の場合は今日を設定
+                  if (status == BookStatus.reading && _startedAt == null) {
+                    _startedAt = today;
+                  }
+
+                  // 読了になったら、終了日が未設定の場合は今日を設定
+                  if (status == BookStatus.finished && _finishedAt == null) {
+                    _finishedAt = today;
+                  }
+                });
+              },
+              onSave: () => _handleSave(existingBook),
+              isRegistered: existingBook != null,
+              isLoading: bookRowAsync.isLoading,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/shared/constants/app_icons.dart
+++ b/lib/shared/constants/app_icons.dart
@@ -14,6 +14,8 @@ class AppIcons {
   static const IconData error = Symbols.error_circle_rounded;
   static const IconData add = Symbols.add_rounded;
   static const IconData addTask = Symbols.add_task_rounded;
+  static const IconData home = Symbols.home_rounded;
+  static const IconData homeFilled = Symbols.home_rounded;
   static const IconData addAlarm = Symbols.alarm_add_rounded;
   static const IconData alarmOff = Symbols.alarm_off_rounded;
   static const IconData alarm = Symbols.alarm_on_rounded;


### PR DESCRIPTION
## Summary
- add a reusable Material 3 NavigationBar and apply it to core pages for consistent routing
- redesign home, search, memo, and action plan screens with updated card-based layouts and sectioned detail views
- refresh shared theming, FAB styling, and reading log cards to match the softer Material 3 look

## Testing
- Not run (environment missing Flutter/SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a5e5b7388329a413f9f070f0ddd2)