### PR TITLE
Add tagging support for books and memos

### DIFF
--- a/lib/core/database/tables.dart
+++ b/lib/core/database/tables.dart
@@ -63,3 +63,30 @@ class ReadingLogs extends Table {
   DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 }
+
+@DataClassName('TagRow')
+class Tags extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get userId => text()();
+  TextColumn get name => text()();
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+@DataClassName('BookTagRow')
+class BookTags extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get bookId => integer()
+      .references(Books, #id, onDelete: KeyAction.cascade)();
+  IntColumn get tagId => integer()
+      .references(Tags, #id, onDelete: KeyAction.cascade)();
+}
+
+@DataClassName('NoteTagRow')
+class NoteTags extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  IntColumn get noteId => integer()
+      .references(Notes, #id, onDelete: KeyAction.cascade)();
+  IntColumn get tagId => integer()
+      .references(Tags, #id, onDelete: KeyAction.cascade)();
+}

--- a/lib/core/providers/tag_providers.dart
+++ b/lib/core/providers/tag_providers.dart
@@ -1,0 +1,50 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../database/app_database.dart';
+import '../repositories/local_database_repository.dart';
+import 'database_providers.dart';
+
+final tagsNotifierProvider =
+    StateNotifierProvider<TagsNotifier, AsyncValue<List<TagRow>>>((ref) {
+  final repository = ref.read(localDatabaseRepositoryProvider);
+  return TagsNotifier(repository)..loadTags();
+});
+
+class TagsNotifier extends StateNotifier<AsyncValue<List<TagRow>>> {
+  TagsNotifier(this._repository) : super(const AsyncValue.loading());
+
+  final LocalDatabaseRepository _repository;
+
+  Future<void> loadTags() async {
+    state = const AsyncValue.loading();
+    try {
+      final tags = await _repository.getAllTags();
+      state = AsyncValue.data(tags);
+    } catch (error, stackTrace) {
+      state = AsyncValue.error(error, stackTrace);
+    }
+  }
+
+  Future<void> addTag(String name) async {
+    if (name.trim().isEmpty) {
+      return;
+    }
+
+    await _repository.createTag(name.trim());
+    await loadTags();
+  }
+
+  Future<void> renameTag(int tagId, String name) async {
+    if (name.trim().isEmpty) {
+      return;
+    }
+
+    await _repository.updateTag(tagId: tagId, name: name.trim());
+    await loadTags();
+  }
+
+  Future<void> deleteTag(int tagId) async {
+    await _repository.deleteTag(tagId);
+    await loadTags();
+  }
+}

--- a/lib/core/widgets/tag_selector.dart
+++ b/lib/core/widgets/tag_selector.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../database/app_database.dart';
+import '../providers/tag_providers.dart';
+import '../../shared/constants/app_icons.dart';
+import 'common_button.dart';
+import 'empty_state.dart';
+import 'loading_indicator.dart';
+
+class TagSelector extends ConsumerWidget {
+  const TagSelector({
+    super.key,
+    required this.selectedTagIds,
+    required this.onSelectionChanged,
+    this.showAddButton = true,
+  });
+
+  final Set<int> selectedTagIds;
+  final ValueChanged<Set<int>> onSelectionChanged;
+  final bool showAddButton;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tagState = ref.watch(tagsNotifierProvider);
+
+    return tagState.when(
+      loading: () => const LoadingIndicator(),
+      error: (error, _) => EmptyState(
+        title: 'タグを読み込めませんでした',
+        message: error.toString(),
+        icon: AppIcons.error,
+      ),
+      data: (tags) {
+        if (tags.isEmpty) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('タグがまだありません'),
+              const SizedBox(height: 8),
+              if (showAddButton)
+                SecondaryButton(
+                  onPressed: () => _showTagDialog(context, ref),
+                  icon: AppIcons.add,
+                  label: 'タグを追加',
+                ),
+            ],
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: tags
+                  .map(
+                    (tag) => FilterChip(
+                      label: Text(tag.name),
+                      selected: selectedTagIds.contains(tag.id),
+                      onSelected: (selected) {
+                        final updated = {...selectedTagIds};
+                        if (selected) {
+                          updated.add(tag.id);
+                        } else {
+                          updated.remove(tag.id);
+                        }
+                        onSelectionChanged(updated);
+                      },
+                    ),
+                  )
+                  .toList(),
+            ),
+            if (showAddButton) ...[
+              const SizedBox(height: 8),
+              TextButton.icon(
+                onPressed: () => _showTagDialog(context, ref),
+                icon: const Icon(AppIcons.add),
+                label: const Text('タグを追加'),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _showTagDialog(BuildContext context, WidgetRef ref) async {
+    final controller = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('タグを追加'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(labelText: 'タグ名'),
+            autofocus: true,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('キャンセル'),
+            ),
+            PrimaryButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              label: '追加',
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed == true) {
+      await ref.read(tagsNotifierProvider.notifier).addTag(controller.text);
+    }
+  }
+}
+
+class TagChipList extends StatelessWidget {
+  const TagChipList({super.key, required this.tags});
+
+  final List<TagRow> tags;
+
+  @override
+  Widget build(BuildContext context) {
+    if (tags.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: tags
+          .map(
+            (tag) => Chip(
+              label: Text(tag.name),
+              visualDensity: VisualDensity.compact,
+            ),
+          )
+          .toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add tag storage, relationships, and CRUD helpers in the local database
- allow creating, editing, and applying tags to books and memos through new UI components
- support filtering local search results by selected tags and display assigned tags in results

## Testing
- Not run (Flutter SDK not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a8ac156483299d79b5d98b021d6f)