### PR TITLE
Add notebook-inspired styling to memo page

### DIFF
--- a/lib/core/widgets/app_page.dart
+++ b/lib/core/widgets/app_page.dart
@@ -14,6 +14,7 @@ class AppPage extends StatelessWidget {
     this.currentDestination,
     this.scrollable = false,
     this.bottom,
+    this.backgroundColor,
   });
 
   final String title;
@@ -25,6 +26,7 @@ class AppPage extends StatelessWidget {
   final AppDestination? currentDestination;
   final bool scrollable;
   final PreferredSizeWidget? bottom;
+  final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +52,7 @@ class AppPage extends StatelessWidget {
       ),
       floatingActionButton: floatingActionButton,
       bottomNavigationBar: navigationBar,
+      backgroundColor: backgroundColor,
       body: SafeArea(child: pageBody),
     );
   }


### PR DESCRIPTION
## Summary
- add optional page background color support to the shared AppPage scaffold
- refresh the memos page with a paper-like background, notebook-style book selector, and spacious note editor fields
- improve memo readability with richer bullet/quote rendering and increased line spacing

## Testing
- not run (environment missing Dart/Flutter SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692309b02fc883299816238f1cc67491)