### PR TITLE
Restyle reading speed chart with fl_chart

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  fl_chart: ^0.69.0
 
   # Theming
   flex_color_scheme: ^8.3.1


### PR DESCRIPTION
## Summary
- replace the weekly reading chart with an fl_chart-driven pastel green bar chart and minimalist styling
- add fl_chart as a dependency for the new chart implementation

## Testing
- Not run (Flutter SDK is not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230b1bc5b4832986282b00edbda166)