### PR TITLE
Implement floating glass card UI

### DIFF
--- a/lib/core/widgets/app_card.dart
+++ b/lib/core/widgets/app_card.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 class AppCard extends StatelessWidget {
@@ -17,29 +19,54 @@ class AppCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final shape = RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(18),
-      side: BorderSide(color: colorScheme.outlineVariant.withOpacity(0.6)),
-    );
+    final radius = BorderRadius.circular(18);
+    final baseColor = backgroundColor ?? colorScheme.surface;
 
-    final card = Card(
-      elevation: 1,
-      color: backgroundColor ?? colorScheme.surface,
-      shadowColor: colorScheme.shadow.withOpacity(0.08),
-      surfaceTintColor: colorScheme.surfaceTint.withOpacity(0.08),
-      shape: shape,
-      clipBehavior: Clip.antiAlias,
-      child: Padding(
-        padding: padding,
-        child: child,
+    final card = ClipRRect(
+      borderRadius: radius,
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: radius,
+            color: baseColor.withOpacity(0.18),
+            gradient: LinearGradient(
+              colors: [
+                Colors.white.withOpacity(0.18),
+                baseColor.withOpacity(0.12),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            border: Border.all(
+              color: colorScheme.outlineVariant.withOpacity(0.4),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: colorScheme.shadow.withOpacity(0.04),
+                blurRadius: 8,
+                offset: const Offset(0, 6),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: padding,
+            child: child,
+          ),
+        ),
       ),
     );
 
     if (onTap != null) {
-      return InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(18),
-        child: card,
+      return Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: radius,
+          splashColor: colorScheme.primary.withOpacity(0.08),
+          highlightColor: colorScheme.primary.withOpacity(0.04),
+          child: card,
+        ),
       );
     }
 

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -426,8 +428,8 @@ class _BookTile extends StatelessWidget {
       decoration: BoxDecoration(
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.08),
-            blurRadius: 12,
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 8,
             offset: const Offset(0, 6),
           ),
         ],
@@ -438,6 +440,26 @@ class _BookTile extends StatelessWidget {
         child: Stack(
           children: [
             Positioned.fill(child: _BookCover(thumbnailUrl: book.thumbnailUrl)),
+            Positioned.fill(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 8, sigmaY: 8),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        Colors.white.withOpacity(0.08),
+                        Theme.of(context)
+                            .colorScheme
+                            .surfaceTint
+                            .withOpacity(0.06),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                ),
+              ),
+            ),
             Positioned.fill(
               child: DecoratedBox(
                 decoration: BoxDecoration(
@@ -465,44 +487,58 @@ class _BookTile extends StatelessWidget {
               left: 0,
               right: 0,
               bottom: 0,
-              child: Container(
-                padding: const EdgeInsets.all(14),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [
-                      Colors.black.withOpacity(0.72),
-                      Colors.black.withOpacity(0.25),
-                    ],
-                    begin: Alignment.bottomCenter,
-                    end: Alignment.topCenter,
-                  ),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      book.title,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context)
-                          .textTheme
-                          .titleMedium
-                          ?.copyWith(color: Colors.white, fontWeight: FontWeight.w800),
-                    ),
-                    if (book.authors != null && book.authors!.isNotEmpty) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        book.authors!,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodySmall
-                            ?.copyWith(color: Colors.white.withOpacity(0.86)),
+              child: ClipRRect(
+                borderRadius:
+                    const BorderRadius.vertical(bottom: Radius.circular(18)),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                  child: Container(
+                    padding: const EdgeInsets.all(14),
+                    decoration: BoxDecoration(
+                      color:
+                          Theme.of(context).colorScheme.surface.withOpacity(0.16),
+                      gradient: LinearGradient(
+                        colors: [
+                          Colors.black.withOpacity(0.24),
+                          Colors.black.withOpacity(0.08),
+                        ],
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
                       ),
-                    ],
-                  ],
+                      border: Border(
+                        top: BorderSide(
+                          color: Colors.white.withOpacity(0.14),
+                        ),
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          book.title,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w800,
+                              ),
+                        ),
+                        if (book.authors != null && book.authors!.isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            book.authors!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(color: Colors.white.withOpacity(0.86)),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- restyle AppCard with glass-like backdrop blur, translucent fill, and subtle shadowing to create a floating feel
- apply the new glass treatment to book tiles on the home screen with toned-down shadows and translucent overlays

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230b9a545c8329bf69a0512a8d77bb)