### PR TITLE
Add gradient backgrounds to page layout

### DIFF
--- a/lib/core/widgets/app_page.dart
+++ b/lib/core/widgets/app_page.dart
@@ -30,6 +30,16 @@ class AppPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final gradientStart = theme.brightness == Brightness.dark
+        ? const Color(0xFF123F2D)
+        : const Color(0xFFE8F5EE);
+    final gradientEnd = backgroundColor ??
+        (theme.brightness == Brightness.dark
+            ? const Color(0xFF0C1E16)
+            : Colors.white);
+
     final pageBody = Padding(
       padding: padding,
       child: scrollable
@@ -53,7 +63,25 @@ class AppPage extends StatelessWidget {
       floatingActionButton: floatingActionButton,
       bottomNavigationBar: navigationBar,
       backgroundColor: backgroundColor,
-      body: SafeArea(child: pageBody),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              gradientStart,
+              gradientEnd,
+            ],
+            stops: const [0.0, 0.65],
+          ),
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(0, 12, 0, 16),
+            child: pageBody,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -80,7 +80,6 @@ class HomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final colorScheme = Theme.of(context).colorScheme;
     final bookshelfState = ref.watch(bookshelfNotifierProvider);
 
     return AppPage(
@@ -104,37 +103,20 @@ class HomePage extends ConsumerWidget {
           icon: const Icon(AppIcons.logout),
         ),
       ],
-      padding: EdgeInsets.zero,
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 24),
       scrollable: true,
       currentDestination: AppDestination.home,
-      child: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              colorScheme.primaryContainer.withOpacity(0.35),
-              colorScheme.surface,
-              colorScheme.surface,
-            ],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            stops: const [0.0, 0.25, 1.0],
-          ),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 20, 16, 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const _HeaderSection(),
-              const SizedBox(height: 18),
-              _ContinueReadingSection(state: bookshelfState),
-              const SizedBox(height: 20),
-              _MagazineGrid(state: bookshelfState),
-              const SizedBox(height: 24),
-              _RecentNotesCarousel(state: bookshelfState),
-            ],
-          ),
-        ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const _HeaderSection(),
+          const SizedBox(height: 18),
+          _ContinueReadingSection(state: bookshelfState),
+          const SizedBox(height: 20),
+          _MagazineGrid(state: bookshelfState),
+          const SizedBox(height: 24),
+          _RecentNotesCarousel(state: bookshelfState),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- introduce light and dark gradient backgrounds in the shared AppPage scaffold
- adjust global page spacing to let the gradient blend with scrolling content
- update the home page to rely on the shared gradient styling

## Testing
- not run (environment missing Dart/Flutter tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230bcef8c083299b0301b006370d81)