### PR TITLE
Add design tokens for layout and typography

### DIFF
--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -3,25 +3,27 @@ import 'package:flutter/material.dart';
 
 import 'color_schemes.dart';
 import 'typography.dart';
+import 'tokens/elevation.dart';
+import 'tokens/radius.dart';
 import '../../shared/constants/app_icons.dart';
 
 class AppTheme {
   static const _subThemes = FlexSubThemesData(
-    defaultRadius: 14,
+    defaultRadius: AppRadius.large,
     appBarBackgroundSchemeColor: SchemeColor.primaryContainer,
     appBarCenterTitle: true,
-    appBarScrolledUnderElevation: 0,
+    appBarScrolledUnderElevation: AppElevation.level0,
     elevatedButtonSchemeColor: SchemeColor.primary,
     elevatedButtonSecondarySchemeColor: SchemeColor.onPrimary,
     outlinedButtonSchemeColor: SchemeColor.primary,
     outlinedButtonOutlineSchemeColor: SchemeColor.primary,
     outlinedButtonBorderWidth: 1.4,
-    cardRadius: 14,
-    cardElevation: 2,
+    cardRadius: AppRadius.large,
+    cardElevation: AppElevation.level2,
     inputDecoratorBorderType: FlexInputBorderType.outline,
     inputDecoratorSchemeColor: SchemeColor.primary,
     inputDecoratorUnfocusedHasBorder: true,
-    inputDecoratorRadius: 14,
+    inputDecoratorRadius: AppRadius.large,
     navigationBarHeight: 72,
     navigationBarIndicatorSchemeColor: SchemeColor.primaryContainer,
     navigationBarSelectedIconSchemeColor: SchemeColor.onPrimaryContainer,
@@ -51,9 +53,9 @@ class AppTheme {
           color: lightColorScheme.onPrimary,
         ),
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
-          elevation: 2,
+          elevation: AppElevation.level2,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(18)),
+            borderRadius: BorderRadius.all(Radius.circular(AppRadius.large)),
           ),
         ),
       );
@@ -77,9 +79,9 @@ class AppTheme {
           color: darkColorScheme.onPrimary,
         ),
         floatingActionButtonTheme: const FloatingActionButtonThemeData(
-          elevation: 2,
+          elevation: AppElevation.level2,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(18)),
+            borderRadius: BorderRadius.all(Radius.circular(AppRadius.large)),
           ),
         ),
       );

--- a/lib/core/theme/tokens/elevation.dart
+++ b/lib/core/theme/tokens/elevation.dart
@@ -1,0 +1,7 @@
+class AppElevation {
+  const AppElevation._();
+
+  static const double level0 = 0;
+  static const double level1 = 1;
+  static const double level2 = 2;
+}

--- a/lib/core/theme/tokens/radius.dart
+++ b/lib/core/theme/tokens/radius.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AppRadius {
+  const AppRadius._();
+
+  static const double small = 8;
+  static const double medium = 12;
+  static const double large = 16;
+
+  static const BorderRadius smallRadius = BorderRadius.all(Radius.circular(small));
+  static const BorderRadius mediumRadius = BorderRadius.all(Radius.circular(medium));
+  static const BorderRadius largeRadius = BorderRadius.all(Radius.circular(large));
+}

--- a/lib/core/theme/tokens/spacing.dart
+++ b/lib/core/theme/tokens/spacing.dart
@@ -1,0 +1,10 @@
+class AppSpacing {
+  const AppSpacing._();
+
+  static const double xSmall = 4;
+  static const double small = 8;
+  static const double medium = 12;
+  static const double large = 16;
+  static const double xLarge = 24;
+  static const double xxLarge = 32;
+}

--- a/lib/core/theme/tokens/text_styles.dart
+++ b/lib/core/theme/tokens/text_styles.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class AppTextStyles {
+  const AppTextStyles._();
+
+  static TextStyle pageTitle(BuildContext context) =>
+      Theme.of(context).textTheme.headlineMedium!;
+
+  static TextStyle sectionTitle(BuildContext context) =>
+      Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w700);
+
+  static TextStyle title(BuildContext context) =>
+      Theme.of(context).textTheme.titleMedium!;
+
+  static TextStyle bodyLarge(BuildContext context) =>
+      Theme.of(context).textTheme.bodyLarge!;
+
+  static TextStyle bodyMedium(BuildContext context) =>
+      Theme.of(context).textTheme.bodyMedium!;
+
+  static TextStyle bodySmall(BuildContext context) =>
+      Theme.of(context).textTheme.bodySmall!;
+
+  static TextStyle labelLarge(BuildContext context) =>
+      Theme.of(context).textTheme.labelLarge!;
+}

--- a/lib/core/widgets/app_card.dart
+++ b/lib/core/widgets/app_card.dart
@@ -2,12 +2,15 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+import '../theme/tokens/radius.dart';
+import '../theme/tokens/spacing.dart';
+
 class AppCard extends StatelessWidget {
   const AppCard({
     super.key,
     required this.child,
     this.onTap,
-    this.padding = const EdgeInsets.all(16),
+    this.padding = const EdgeInsets.all(AppSpacing.large),
     this.backgroundColor,
   });
 
@@ -19,13 +22,16 @@ class AppCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final radius = BorderRadius.circular(18);
+    const radius = AppRadius.largeRadius;
     final baseColor = backgroundColor ?? colorScheme.surface;
 
     final card = ClipRRect(
       borderRadius: radius,
       child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        filter: ImageFilter.blur(
+          sigmaX: AppSpacing.xLarge,
+          sigmaY: AppSpacing.xLarge,
+        ),
         child: DecoratedBox(
           decoration: BoxDecoration(
             borderRadius: radius,
@@ -44,8 +50,8 @@ class AppCard extends StatelessWidget {
             boxShadow: [
               BoxShadow(
                 color: colorScheme.shadow.withOpacity(0.04),
-                blurRadius: 8,
-                offset: const Offset(0, 6),
+                blurRadius: AppSpacing.small,
+                offset: const Offset(0, AppSpacing.medium),
               ),
             ],
           ),

--- a/lib/core/widgets/app_page.dart
+++ b/lib/core/widgets/app_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../theme/tokens/spacing.dart';
 import 'app_navigation_bar.dart';
 
 class AppPage extends StatelessWidget {
@@ -8,7 +9,7 @@ class AppPage extends StatelessWidget {
     required this.title,
     required this.child,
     this.actions,
-    this.padding = const EdgeInsets.all(24),
+    this.padding = const EdgeInsets.all(AppSpacing.xLarge),
     this.floatingActionButton,
     this.bottomNavigationBar,
     this.currentDestination,
@@ -77,7 +78,12 @@ class AppPage extends StatelessWidget {
         ),
         child: SafeArea(
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(0, 12, 0, 16),
+            padding: const EdgeInsets.fromLTRB(
+              0,
+              AppSpacing.medium,
+              0,
+              AppSpacing.large,
+            ),
             child: pageBody,
           ),
         ),

--- a/lib/features/action_plans/action_plans_feature.dart
+++ b/lib/features/action_plans/action_plans_feature.dart
@@ -5,6 +5,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
+import '../../core/theme/tokens/radius.dart';
+import '../../core/theme/tokens/spacing.dart';
+import '../../core/theme/tokens/text_styles.dart';
 import '../../core/widgets/app_navigation_bar.dart';
 import '../../core/widgets/app_page.dart';
 import '../../shared/constants/app_icons.dart';
@@ -231,14 +234,14 @@ class ActionPlansPage extends ConsumerWidget {
 
     return AppPage(
       title: 'アクションプラン',
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(AppSpacing.large),
       currentDestination: AppDestination.actions,
       child: Column(
         children: [
           _BookSelector(state: state),
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.large),
           _StatusFilterRow(state: state),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           Expanded(child: _ActionList(state: state)),
         ],
       ),
@@ -277,7 +280,7 @@ class _BookSelector extends ConsumerWidget {
     return Row(
       children: [
         const Icon(AppIcons.menuBook),
-        const SizedBox(width: 12),
+        const SizedBox(width: AppSpacing.medium),
         Expanded(
           child: DropdownButton<int>(
             value: state.selectedBookId,
@@ -317,7 +320,7 @@ class _StatusFilterRow extends ConsumerWidget {
         children: ActionStatusFilter.values.map((filter) {
           final isSelected = state.statusFilter == filter;
           return Padding(
-            padding: const EdgeInsets.only(right: 8),
+            padding: const EdgeInsets.only(right: AppSpacing.small),
             child: ChoiceChip(
               label: Text(_statusFilterLabel(filter)),
               selected: isSelected,
@@ -364,7 +367,7 @@ class _ActionList extends ConsumerWidget {
 
         return ListView.separated(
           itemCount: filteredActions.length,
-          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          separatorBuilder: (_, __) => const SizedBox(height: AppSpacing.medium),
           itemBuilder: (context, index) {
             final action = filteredActions[index];
             return _ActionTile(action: action, notes: state.notes);
@@ -447,7 +450,7 @@ class _ActionTile extends ConsumerWidget {
 
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(AppSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -465,7 +468,7 @@ class _ActionTile extends ConsumerWidget {
                     children: [
                       Text(
                         action.title,
-                        style: theme.textTheme.titleMedium?.copyWith(
+                        style: AppTextStyles.title(context).copyWith(
                           decoration: isDone
                               ? TextDecoration.lineThrough
                               : TextDecoration.none,
@@ -473,16 +476,16 @@ class _ActionTile extends ConsumerWidget {
                       ),
                       if (action.description?.isNotEmpty ?? false)
                         Padding(
-                          padding: const EdgeInsets.only(top: 4),
+                          padding: const EdgeInsets.only(top: AppSpacing.xSmall),
                           child: Text(
                             action.description!,
-                            style: theme.textTheme.bodyMedium,
+                            style: AppTextStyles.bodyMedium(context),
                           ),
                         ),
-                      const SizedBox(height: 8),
+                      const SizedBox(height: AppSpacing.small),
                       Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
+                        spacing: AppSpacing.small,
+                        runSpacing: AppSpacing.small,
                         children: [
                           Chip(
                             avatar: Icon(
@@ -524,15 +527,15 @@ class _ActionTile extends ConsumerWidget {
                         ],
                       ),
                     ],
-                  ),
+                    ),
                 ),
                 _ActionMenu(action: action),
               ],
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             Wrap(
-              spacing: 8,
-              runSpacing: 8,
+              spacing: AppSpacing.small,
+              runSpacing: AppSpacing.small,
               children: [
                 if (!isDone)
                   FilledButton.icon(
@@ -565,11 +568,11 @@ class _ActionTile extends ConsumerWidget {
             ),
             if (isReminderDue && !isDone)
               Padding(
-                padding: const EdgeInsets.only(top: 8),
+                padding: const EdgeInsets.only(top: AppSpacing.small),
                 child: Text(
                   'リマインドの時間になりました。進捗を確認しましょう。',
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.primary),
+                  style: AppTextStyles.bodySmall(context)
+                      .copyWith(color: theme.colorScheme.primary),
                 ),
               ),
           ],
@@ -587,7 +590,7 @@ class _ActionMenu extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Wrap(
-      spacing: 4,
+      spacing: AppSpacing.xSmall,
       children: [
         IconButton(
           tooltip: '編集',
@@ -690,7 +693,7 @@ Future<void> showActionPlanDialog(
                         return null;
                       },
                     ),
-                    const SizedBox(height: 12),
+                    const SizedBox(height: AppSpacing.medium),
                     TextFormField(
                       controller: descriptionController,
                       decoration: const InputDecoration(
@@ -698,7 +701,7 @@ Future<void> showActionPlanDialog(
                       ),
                       maxLines: 3,
                     ),
-                    const SizedBox(height: 12),
+                    const SizedBox(height: AppSpacing.medium),
                     Row(
                       children: [
                         Expanded(
@@ -717,7 +720,7 @@ Future<void> showActionPlanDialog(
                               });
                             },
                             icon: const Icon(AppIcons.close),
-                          ),
+                        ),
                         TextButton.icon(
                           onPressed: pickDate,
                           icon: const Icon(AppIcons.calendar),
@@ -725,7 +728,7 @@ Future<void> showActionPlanDialog(
                         ),
                       ],
                     ),
-                    const SizedBox(height: 12),
+                    const SizedBox(height: AppSpacing.medium),
                     Row(
                       children: [
                         Expanded(
@@ -744,7 +747,7 @@ Future<void> showActionPlanDialog(
                               });
                             },
                             icon: const Icon(AppIcons.alarmOff),
-                          ),
+                        ),
                         TextButton.icon(
                           onPressed: pickReminderDate,
                           icon: const Icon(AppIcons.alarm),
@@ -752,7 +755,7 @@ Future<void> showActionPlanDialog(
                         ),
                       ],
                     ),
-                    const SizedBox(height: 12),
+                    const SizedBox(height: AppSpacing.medium),
                     DropdownButtonFormField<int?>(
                       value: selectedNoteId,
                       decoration: const InputDecoration(
@@ -895,15 +898,15 @@ class _InfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(AppSpacing.large),
         child: Row(
           children: [
             Icon(icon, size: 28),
-            const SizedBox(width: 12),
+            const SizedBox(width: AppSpacing.medium),
             Expanded(
               child: Text(
                 message,
-                style: Theme.of(context).textTheme.bodyMedium,
+                style: AppTextStyles.bodyMedium(context),
               ),
             ),
           ],

--- a/lib/features/auth/login_page.dart
+++ b/lib/features/auth/login_page.dart
@@ -4,6 +4,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/providers/auth_providers.dart';
+import '../../core/theme/tokens/radius.dart';
+import '../../core/theme/tokens/spacing.dart';
+import '../../core/theme/tokens/text_styles.dart';
 import '../../core/widgets/app_page.dart';
 import '../../core/widgets/common_button.dart';
 import '../../shared/constants/app_constants.dart';
@@ -85,15 +88,16 @@ class _LoginPageState extends ConsumerState<LoginPage> {
         children: [
           Text(
             'メールアドレスでログイン',
-            style: Theme.of(context).textTheme.headlineMedium,
+            style: AppTextStyles.pageTitle(context),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           Text(
             'メールアドレスを入力すると、ログイン用のMagic Linkを送信します。',
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant),
+            style: AppTextStyles.bodyLarge(context).copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xLarge),
           Form(
             key: _formKey,
             child: Column(
@@ -115,7 +119,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                     return null;
                   },
                 ),
-                const SizedBox(height: 16),
+                const SizedBox(height: AppSpacing.large),
                 PrimaryButton(
                   onPressed: _sendMagicLink,
                   label: 'Magic Linkを送信',
@@ -129,7 +133,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
               ],
             ),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.large),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
@@ -145,10 +149,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
           if (magicLinkSent)
             Container(
               width: double.infinity,
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.all(AppSpacing.medium),
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.secondaryContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.mediumRadius,
               ),
               child: Row(
                 children: [
@@ -156,24 +160,24 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                     AppIcons.email,
                     color: Theme.of(context).colorScheme.secondary,
                   ),
-                  const SizedBox(width: 12),
+                    const SizedBox(width: AppSpacing.medium),
                   Expanded(
                     child: Text(
                       'Magic Linkを送信しました。メールボックスを確認してください。',
-                      style: Theme.of(context).textTheme.bodyLarge,
+                      style: AppTextStyles.bodyLarge(context),
                     ),
                   ),
                 ],
               ),
             ),
           if (authError != null) ...[
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             Container(
               width: double.infinity,
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.all(AppSpacing.medium),
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.errorContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.mediumRadius,
               ),
               child: Row(
                 children: [
@@ -181,17 +185,17 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                     AppIcons.error,
                     color: Theme.of(context).colorScheme.error,
                   ),
-                  const SizedBox(width: 12),
+                    const SizedBox(width: AppSpacing.medium),
                   Expanded(
                     child: Text(
                       authError,
                       style: Theme.of(context)
                           .textTheme
-                          .bodyLarge
+                        .bodyLarge
                           ?.copyWith(
-                              color: Theme.of(context)
-                                  .colorScheme
-                                  .onErrorContainer),
+                        color:
+                            Theme.of(context).colorScheme.onErrorContainer,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/features/auth/signup_page.dart
+++ b/lib/features/auth/signup_page.dart
@@ -3,6 +3,9 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../core/providers/auth_providers.dart';
+import '../../core/theme/tokens/radius.dart';
+import '../../core/theme/tokens/spacing.dart';
+import '../../core/theme/tokens/text_styles.dart';
 import '../../core/widgets/app_page.dart';
 import '../../core/widgets/common_button.dart';
 import '../../shared/constants/app_constants.dart';
@@ -67,17 +70,16 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
         children: [
           Text(
             '新規アカウント作成',
-            style: Theme.of(context).textTheme.headlineMedium,
+            style: AppTextStyles.pageTitle(context),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           Text(
             'メールアドレスを入力すると、登録用のMagic Linkを送信します。',
-            style: Theme.of(context)
-                .textTheme
-                .bodyLarge
-                ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+            style: AppTextStyles.bodyLarge(context).copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xLarge),
           Form(
             key: _formKey,
             child: Column(
@@ -99,7 +101,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                     return null;
                   },
                 ),
-                const SizedBox(height: 16),
+                const SizedBox(height: AppSpacing.large),
                 PrimaryButton(
                   onPressed: _sendSignUpLink,
                   label: '登録リンクを送信',
@@ -108,7 +110,7 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
               ],
             ),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.large),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
@@ -122,10 +124,10 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
           if (magicLinkSent)
             Container(
               width: double.infinity,
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.all(AppSpacing.medium),
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.secondaryContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.mediumRadius,
               ),
               child: Row(
                 children: [
@@ -133,24 +135,24 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                     AppIcons.email,
                     color: Theme.of(context).colorScheme.secondary,
                   ),
-                  const SizedBox(width: 12),
+                  const SizedBox(width: AppSpacing.medium),
                   Expanded(
                     child: Text(
                       '登録用のMagic Linkを送信しました。メールを確認してください。',
-                      style: Theme.of(context).textTheme.bodyLarge,
+                      style: AppTextStyles.bodyLarge(context),
                     ),
                   ),
                 ],
               ),
             ),
           if (authError != null) ...[
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             Container(
               width: double.infinity,
-              padding: const EdgeInsets.all(12),
+              padding: const EdgeInsets.all(AppSpacing.medium),
               decoration: BoxDecoration(
                 color: Theme.of(context).colorScheme.errorContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.mediumRadius,
               ),
               child: Row(
                 children: [
@@ -158,14 +160,16 @@ class _SignUpPageState extends ConsumerState<SignUpPage> {
                     AppIcons.error,
                     color: Theme.of(context).colorScheme.error,
                   ),
-                  const SizedBox(width: 12),
+                  const SizedBox(width: AppSpacing.medium),
                   Expanded(
                     child: Text(
                       authError,
                       style: Theme.of(context)
                           .textTheme
                           .bodyLarge
-                          ?.copyWith(color: Theme.of(context).colorScheme.onErrorContainer),
+                          ?.copyWith(
+                        color: Theme.of(context).colorScheme.onErrorContainer,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/features/memos/memos_feature.dart
+++ b/lib/features/memos/memos_feature.dart
@@ -5,6 +5,9 @@ import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/providers/tag_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
+import '../../core/theme/tokens/radius.dart';
+import '../../core/theme/tokens/spacing.dart';
+import '../../core/theme/tokens/text_styles.dart';
 import '../../core/widgets/app_card.dart';
 import '../../core/widgets/app_navigation_bar.dart';
 import '../../core/widgets/app_page.dart';
@@ -166,15 +169,15 @@ class MemosPage extends ConsumerWidget {
 
     return AppPage(
       title: '読書メモ',
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(AppSpacing.large),
       currentDestination: AppDestination.memos,
       backgroundColor: _paperColor,
       child: Column(
         children: [
           const _TagManagerSection(),
-          const SizedBox(height: 12),
+          const SizedBox(height: AppSpacing.medium),
           _BookSelector(state: state),
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.large),
           Expanded(child: _MemoList(state: state)),
         ],
       ),
@@ -196,17 +199,17 @@ class _TagManagerSection extends ConsumerWidget {
     final tagState = ref.watch(tagsNotifierProvider);
 
     return AppCard(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(AppSpacing.medium),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
               const Icon(AppIcons.label),
-              const SizedBox(width: 8),
-              const Text(
+              const SizedBox(width: AppSpacing.small),
+              Text(
                 'タグ管理',
-                style: TextStyle(fontWeight: FontWeight.bold),
+                style: AppTextStyles.sectionTitle(context),
               ),
               const Spacer(),
               IconButton(
@@ -221,7 +224,7 @@ class _TagManagerSection extends ConsumerWidget {
               ),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           tagState.when(
             loading: () => const LoadingIndicator(),
             error: (error, _) => Text('タグの取得に失敗しました: $error'),
@@ -231,8 +234,8 @@ class _TagManagerSection extends ConsumerWidget {
               }
 
               return Wrap(
-                spacing: 8,
-                runSpacing: 8,
+                spacing: AppSpacing.small,
+                runSpacing: AppSpacing.small,
                 children: tags
                     .map(
                       (tag) => InputChip(
@@ -355,10 +358,13 @@ class _BookSelector extends ConsumerWidget {
 
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.large,
+        vertical: AppSpacing.medium,
+      ),
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.largeRadius,
         border: Border.all(color: colorScheme.outlineVariant.withOpacity(0.6)),
       ),
       child: Column(
@@ -366,22 +372,22 @@ class _BookSelector extends ConsumerWidget {
         children: [
           Text(
             '書籍ノート',
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 0.4,
-                ),
+            style: AppTextStyles.title(context).copyWith(
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.4,
+            ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           Row(
             children: [
               const Icon(AppIcons.menuBook),
-              const SizedBox(width: 12),
+              const SizedBox(width: AppSpacing.medium),
               Expanded(
                 child: DropdownButtonHideUnderline(
                   child: DropdownButton<int>(
                     value: state.selectedBookId,
                     isExpanded: true,
-                    borderRadius: BorderRadius.circular(14),
+                    borderRadius: AppRadius.largeRadius,
                     items: state.books
                         .map(
                           (book) => DropdownMenuItem(
@@ -434,7 +440,7 @@ class _MemoList extends ConsumerWidget {
 
         return ListView.separated(
           itemCount: notes.length,
-          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          separatorBuilder: (_, __) => const SizedBox(height: AppSpacing.medium),
           itemBuilder: (context, index) {
             final note = notes[index];
             return _MemoCard(note: note);
@@ -466,7 +472,7 @@ class _MemoCard extends ConsumerWidget {
     );
 
     return AppCard(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(AppSpacing.large),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -483,14 +489,14 @@ class _MemoCard extends ConsumerWidget {
               _MemoActions(note: note),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           _MemoContent(text: note.content),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.small),
           TagChipList(
             tags:
                 ref.watch(memosNotifierProvider).noteTags[note.id] ?? const [],
           ),
-          const SizedBox(height: 12),
+          const SizedBox(height: AppSpacing.medium),
           Row(
             children: [
               Icon(
@@ -498,11 +504,12 @@ class _MemoCard extends ConsumerWidget {
                 size: AppIconSizes.small,
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),
-              const SizedBox(width: 6),
+              const SizedBox(width: AppSpacing.small),
               Text(
                 '作成: $createdDate $createdTime',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant),
+                style: AppTextStyles.bodySmall(context).copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),
@@ -520,7 +527,7 @@ class _MemoContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final baseStyle =
-        Theme.of(context).textTheme.bodyLarge?.copyWith(height: 1.7);
+        AppTextStyles.bodyLarge(context).copyWith(height: 1.7);
     final bulletStyle = baseStyle?.copyWith(fontWeight: FontWeight.w600);
     final quoteStyle = baseStyle?.copyWith(
       fontStyle: FontStyle.italic,
@@ -534,7 +541,7 @@ class _MemoContent extends StatelessWidget {
       children: [
         for (final line in lines)
           Padding(
-            padding: const EdgeInsets.symmetric(vertical: 3),
+            padding: const EdgeInsets.symmetric(vertical: AppSpacing.xSmall),
             child: _buildStyledLine(
               context,
               line,
@@ -555,7 +562,7 @@ class _MemoContent extends StatelessWidget {
     TextStyle? quoteStyle,
   ) {
     if (line.trim().isEmpty) {
-      return const SizedBox(height: 8);
+      return const SizedBox(height: AppSpacing.small);
     }
 
     final bulletMatch = RegExp(r'^\s*[-*・]\s+(.*)$').firstMatch(line);
@@ -565,10 +572,10 @@ class _MemoContent extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
-            padding: const EdgeInsets.only(top: 4),
+            padding: const EdgeInsets.only(top: AppSpacing.xSmall),
             child: Text('•', style: bulletStyle),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: AppSpacing.small),
           Expanded(
             child: Text(
               bulletText,
@@ -588,15 +595,18 @@ class _MemoContent extends StatelessWidget {
         width: double.infinity,
         decoration: BoxDecoration(
           color: colorScheme.surface.withOpacity(0.7),
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: AppRadius.mediumRadius,
           border: Border(
             left: BorderSide(
               color: colorScheme.outlineVariant,
-              width: 3,
+              width: AppSpacing.xSmall,
             ),
           ),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.medium,
+          vertical: AppSpacing.small,
+        ),
         child: Text(
           quoteText,
           style: quoteStyle,
@@ -622,7 +632,7 @@ class _MemoActions extends ConsumerWidget {
     final selectedBookId = ref.watch(memosNotifierProvider).selectedBookId;
 
     return Wrap(
-      spacing: 8,
+      spacing: AppSpacing.small,
       children: [
         IconButton(
           tooltip: '編集',
@@ -683,11 +693,11 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                     filled: true,
                     fillColor: Colors.white,
                     contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 14,
+                      horizontal: AppSpacing.large,
+                      vertical: AppSpacing.medium,
                     ),
                     border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: AppRadius.largeRadius,
                       borderSide: BorderSide(
                         color: Theme.of(context)
                             .colorScheme
@@ -696,7 +706,7 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                       ),
                     ),
                     enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: AppRadius.largeRadius,
                       borderSide: BorderSide(
                         color: Theme.of(context)
                             .colorScheme
@@ -705,7 +715,7 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: AppRadius.largeRadius,
                       borderSide: BorderSide(
                         color: Theme.of(context).colorScheme.primary,
                         width: 1.4,
@@ -715,7 +725,7 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                   ),
                   maxLines: null,
                   minLines: 6,
-                  style: const TextStyle(height: 1.6),
+                  style: AppTextStyles.bodyLarge(context).copyWith(height: 1.6),
                   validator: (value) {
                     if (value == null || value.trim().isEmpty) {
                       return 'メモを入力してください';
@@ -723,7 +733,7 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                     return null;
                   },
                 ),
-                const SizedBox(height: 12),
+                const SizedBox(height: AppSpacing.medium),
                 TextFormField(
                   controller: pageController,
                   decoration: InputDecoration(
@@ -732,11 +742,11 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                     filled: true,
                     fillColor: Colors.white,
                     contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 14,
+                      horizontal: AppSpacing.large,
+                      vertical: AppSpacing.medium,
                     ),
                     border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(14),
+                      borderRadius: AppRadius.mediumRadius,
                       borderSide: BorderSide(
                         color: Theme.of(context)
                             .colorScheme
@@ -745,7 +755,7 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                       ),
                     ),
                     enabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(14),
+                      borderRadius: AppRadius.mediumRadius,
                       borderSide: BorderSide(
                         color: Theme.of(context)
                             .colorScheme
@@ -754,7 +764,7 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                       ),
                     ),
                     focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(14),
+                      borderRadius: AppRadius.mediumRadius,
                       borderSide: BorderSide(
                         color: Theme.of(context).colorScheme.primary,
                         width: 1.2,
@@ -763,18 +773,16 @@ Future<void> _showNoteDialog(BuildContext context, WidgetRef ref,
                   ),
                   keyboardType: TextInputType.number,
                 ),
-                const SizedBox(height: 12),
+                const SizedBox(height: AppSpacing.medium),
                 Align(
                   alignment: Alignment.centerLeft,
                   child: Text(
                     'タグ',
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleSmall
-                        ?.copyWith(fontWeight: FontWeight.bold),
+                    style: AppTextStyles.title(context)
+                        .copyWith(fontWeight: FontWeight.bold),
                   ),
                 ),
-                const SizedBox(height: 8),
+                const SizedBox(height: AppSpacing.small),
                 TagSelector(
                   selectedTagIds: selectedTagIds,
                   onSelectionChanged: (ids) {

--- a/lib/features/reading_speed/reading_speed_feature.dart
+++ b/lib/features/reading_speed/reading_speed_feature.dart
@@ -8,6 +8,9 @@ import '../../core/database/app_database.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
 import '../../core/widgets/app_card.dart';
+import '../../core/theme/tokens/radius.dart';
+import '../../core/theme/tokens/spacing.dart';
+import '../../core/theme/tokens/text_styles.dart';
 import '../../shared/constants/app_icons.dart';
 
 final readingSpeedNotifierProvider =
@@ -261,18 +264,18 @@ class _ReadingSpeedPageState extends ConsumerState<ReadingSpeedPage> {
               : state.error != null
                   ? _ErrorCard(message: state.error!)
                   : ListView(
-                      padding: const EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(AppSpacing.large),
                       children: [
                         _SummarySection(state: state),
-                        const SizedBox(height: 16),
+                        const SizedBox(height: AppSpacing.large),
                         _ReadingLogForm(
                           state: state,
                           pagesController: _pagesController,
                           durationController: _durationController,
                         ),
-                        const SizedBox(height: 16),
+                        const SizedBox(height: AppSpacing.large),
                         _ReadingChart(points: state.recentDailyPoints),
-                        const SizedBox(height: 16),
+                        const SizedBox(height: AppSpacing.large),
                         _ReadingLogList(logs: state.logs),
                       ],
                     ),
@@ -299,7 +302,7 @@ class _SummarySection extends StatelessWidget {
             color: Colors.blue,
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: AppSpacing.medium),
         Expanded(
           child: _SummaryCard(
             title: '今週',
@@ -308,7 +311,7 @@ class _SummarySection extends StatelessWidget {
             color: Colors.green,
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: AppSpacing.medium),
         Expanded(
           child: _SummaryCard(
             title: '今月',
@@ -339,26 +342,26 @@ class _SummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(AppSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Row(
               children: [
                 Icon(icon, color: color),
-                const SizedBox(width: 8),
+                const SizedBox(width: AppSpacing.small),
                 Text(
                   title,
-                  style: Theme.of(context).textTheme.titleMedium,
+                  style: AppTextStyles.title(context),
                 ),
               ],
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             Text(
               value,
-              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              style: AppTextStyles.pageTitle(context).copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ],
         ),
@@ -389,15 +392,15 @@ class _ReadingLogForm extends ConsumerWidget {
 
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(AppSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               '読書ログを追加',
-              style: Theme.of(context).textTheme.titleMedium,
+              style: AppTextStyles.title(context),
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             DropdownButtonFormField<int>(
               value: state.selectedBookId,
               decoration: const InputDecoration(
@@ -420,7 +423,7 @@ class _ReadingLogForm extends ConsumerWidget {
                 }
               },
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             TextField(
               controller: pagesController,
               decoration: const InputDecoration(
@@ -430,7 +433,7 @@ class _ReadingLogForm extends ConsumerWidget {
               ),
               keyboardType: TextInputType.number,
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             TextField(
               controller: durationController,
               decoration: const InputDecoration(
@@ -440,7 +443,7 @@ class _ReadingLogForm extends ConsumerWidget {
               ),
               keyboardType: TextInputType.number,
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             SizedBox(
               width: double.infinity,
               child: ElevatedButton.icon(
@@ -539,15 +542,15 @@ class _ReadingChart extends StatelessWidget {
     return Card(
       color: colorScheme.surfaceVariant.withOpacity(0.32),
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(AppSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               '直近1週間の推移',
-              style: textTheme.titleMedium,
+              style: AppTextStyles.title(context),
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.medium),
             if (points.isEmpty)
               const _InfoCard(
                 icon: AppIcons.barChart,
@@ -557,18 +560,20 @@ class _ReadingChart extends StatelessWidget {
               Column(
                 children: [
                   Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xSmall,
+                    ),
                     child: Row(
                       children: [
                         Container(
-                          width: 12,
-                          height: 12,
+                          width: AppSpacing.medium,
+                          height: AppSpacing.medium,
                           decoration: BoxDecoration(
                             color: barColor,
-                            borderRadius: BorderRadius.circular(4),
+                            borderRadius: AppRadius.smallRadius,
                           ),
                         ),
-                        const SizedBox(width: 8),
+                        const SizedBox(width: AppSpacing.small),
                         Text(
                           '読んだページ数',
                           style:
@@ -577,7 +582,7 @@ class _ReadingChart extends StatelessWidget {
                       ],
                     ),
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: AppSpacing.small),
                   SizedBox(
                     height: 220,
                     child: BarChart(
@@ -598,11 +603,13 @@ class _ReadingChart extends StatelessWidget {
                           enabled: true,
                           handleBuiltInTouches: true,
                           touchTooltipData: BarTouchTooltipData(
-                            tooltipMargin: 6,
+                            tooltipMargin: AppSpacing.xSmall,
                             maxContentWidth: 140,
                             tooltipPadding: const EdgeInsets.symmetric(
-                                horizontal: 10, vertical: 8),
-                            tooltipRoundedRadius: 12,
+                              horizontal: AppSpacing.small,
+                              vertical: AppSpacing.small,
+                            ),
+                            tooltipRoundedRadius: AppRadius.medium,
                             getTooltipColor: (group) =>
                                 colorScheme.surfaceVariant.withOpacity(0.85),
                             getTooltipItem: (group, groupIndex, rod, rodIndex) {
@@ -645,7 +652,8 @@ class _ReadingChart extends StatelessWidget {
                                 }
                                 final point = points[index];
                                 return Padding(
-                                  padding: const EdgeInsets.only(top: 6),
+                                  padding:
+                                      const EdgeInsets.only(top: AppSpacing.xSmall),
                                   child: Text(
                                     '${point.date.month}/${point.date.day}',
                                     style: textTheme.bodySmall?.copyWith(
@@ -663,7 +671,9 @@ class _ReadingChart extends StatelessWidget {
                               reservedSize: 40,
                               interval: gridInterval,
                               getTitlesWidget: (value, meta) => Padding(
-                                padding: const EdgeInsets.only(right: 6),
+                                padding: const EdgeInsets.only(
+                                  right: AppSpacing.xSmall,
+                                ),
                                 child: Text(
                                   value.toInt().toString(),
                                   style: textTheme.bodySmall?.copyWith(
@@ -680,13 +690,13 @@ class _ReadingChart extends StatelessWidget {
                           final point = entry.value;
                           return BarChartGroupData(
                             x: index,
-                            barsSpace: 4,
+                            barsSpace: AppSpacing.xSmall,
                             barRods: [
                               BarChartRodData(
                                 toY: point.pages.toDouble(),
-                                width: 16,
+                                width: AppSpacing.large,
                                 color: barColor,
-                                borderRadius: BorderRadius.circular(7),
+                                borderRadius: AppRadius.smallRadius,
                                 backDrawRodData: BackgroundBarChartRodData(
                                   show: true,
                                   toY: maxY,
@@ -728,59 +738,56 @@ class _ReadingLogList extends StatelessWidget {
       children: [
         Text(
           '最近の記録',
-          style: Theme.of(context).textTheme.titleMedium,
+          style: AppTextStyles.title(context),
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: AppSpacing.medium),
         ...logs.map((entry) {
           final localization = MaterialLocalizations.of(context);
           final logDate = entry.log.loggedAt.toLocal();
           final dateLabel = localization.formatShortDate(logDate);
-          final pages =
-              max(0, (entry.log.endPage ?? 0) - (entry.log.startPage ?? 0));
+        final pages =
+            max(0, (entry.log.endPage ?? 0) - (entry.log.startPage ?? 0));
 
-          return AppCard(
-            padding: const EdgeInsets.all(14),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
+        return AppCard(
+          padding: const EdgeInsets.all(AppSpacing.large),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
                 Row(
                   children: [
                     Expanded(
                       child: Text(
                         entry.book?.title ?? '不明な本',
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleMedium
-                            ?.copyWith(fontWeight: FontWeight.w700),
+                        style: AppTextStyles.title(context)
+                            .copyWith(fontWeight: FontWeight.w700),
                       ),
                     ),
-                    if (entry.log.durationMinutes != null)
-                      Chip(
-                        label: Text('${entry.log.durationMinutes} 分'),
-                        avatar: const Icon(AppIcons.timelapse,
-                            size: AppIconSizes.small),
-                        visualDensity: VisualDensity.compact,
-                      ),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    Icon(
-                      AppIcons.today,
-                      size: AppIconSizes.small,
+                if (entry.log.durationMinutes != null)
+                  Chip(
+                    label: Text('${entry.log.durationMinutes} 分'),
+                    avatar: const Icon(AppIcons.timelapse,
+                        size: AppIconSizes.small),
+                    visualDensity: VisualDensity.compact,
+                  ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.small),
+            Row(
+              children: [
+                  Icon(
+                    AppIcons.today,
+                    size: AppIconSizes.small,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: AppSpacing.small),
+                  Text(
+                    '$dateLabel · $pages ページ',
+                    style: AppTextStyles.bodySmall(context).copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
-                    const SizedBox(width: 6),
-                    Text(
-                      '$dateLabel · $pages ページ',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color:
-                                Theme.of(context).colorScheme.onSurfaceVariant,
-                          ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
+              ),
               ],
             ),
           );
@@ -800,15 +807,15 @@ class _InfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(AppSpacing.medium),
         child: Row(
           children: [
             Icon(icon, size: AppIconSizes.large),
-            const SizedBox(width: 12),
+            const SizedBox(width: AppSpacing.medium),
             Expanded(
               child: Text(
                 message,
-                style: Theme.of(context).textTheme.bodyMedium,
+                style: AppTextStyles.bodyMedium(context),
               ),
             ),
           ],
@@ -829,20 +836,18 @@ class _ErrorCard extends StatelessWidget {
       child: Card(
         color: Colors.red.shade50,
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(AppSpacing.large),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               const Icon(AppIcons.error, color: Colors.red),
-              const SizedBox(height: 8),
+              const SizedBox(height: AppSpacing.small),
               Text(
                 '読み込みに失敗しました',
-                style: Theme.of(context)
-                    .textTheme
-                    .titleMedium
-                    ?.copyWith(color: Colors.red),
+                style:
+                    AppTextStyles.title(context).copyWith(color: Colors.red),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: AppSpacing.small),
               Text(
                 message,
                 textAlign: TextAlign.center,


### PR DESCRIPTION
## Summary
- introduce design tokens for spacing, radius, elevation, and typography
- replace screen-level magic numbers with shared tokens across auth, memos, actions, and reading speed views
- align theme and shared widgets with the new tokenized design language

## Testing
- Not run (Dart SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692314a4f0c083298b1e925184d95e23)