### PR TITLE
Improve typography and add font size settings

### DIFF
--- a/lib/core/providers/settings_providers.dart
+++ b/lib/core/providers/settings_providers.dart
@@ -1,0 +1,29 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../theme/typography.dart';
+
+class FontScaleNotifier extends StateNotifier<AppFontScale> {
+  FontScaleNotifier() : super(AppFontScale.normal) {
+    _loadFromStorage();
+  }
+
+  static const _fontScaleKey = 'app_font_scale';
+
+  Future<void> _loadFromStorage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedIndex = prefs.getInt(_fontScaleKey);
+    if (savedIndex != null && savedIndex >= 0 && savedIndex < AppFontScale.values.length) {
+      state = AppFontScale.values[savedIndex];
+    }
+  }
+
+  Future<void> update(AppFontScale scale) async {
+    state = scale;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_fontScaleKey, scale.index);
+  }
+}
+
+final fontScaleProvider =
+    StateNotifierProvider<FontScaleNotifier, AppFontScale>((ref) => FontScaleNotifier());

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -34,16 +34,17 @@ class AppTheme {
     navigationBarOpacity: 0.95,
   );
 
-  static ThemeData get lightTheme => FlexThemeData.light(
+  static ThemeData lightTheme(AppFontScale fontScale) => FlexThemeData.light(
         colors: lightScheme,
         surfaceMode: FlexSurfaceMode.levelSurfacesLowScaffold,
         blendLevel: 9,
         useMaterial3: true,
-        textTheme: lightTextTheme(),
+        textTheme: lightTextTheme(fontScale),
         fontFamily: primaryFontFamily,
         subThemesData: _subThemes,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ).copyWith(
+        fontFamilyFallback: memoFontFallbacks,
         iconTheme: IconThemeData(
           size: AppIconSizes.medium,
           color: lightColorScheme.onSurfaceVariant,
@@ -80,16 +81,17 @@ class AppTheme {
         ),
       );
 
-  static ThemeData get darkTheme => FlexThemeData.dark(
+  static ThemeData darkTheme(AppFontScale fontScale) => FlexThemeData.dark(
         colors: darkScheme,
         surfaceMode: FlexSurfaceMode.levelSurfacesLowScaffold,
         blendLevel: 15,
         useMaterial3: true,
-        textTheme: darkTextTheme(),
+        textTheme: darkTextTheme(fontScale),
         fontFamily: primaryFontFamily,
         subThemesData: _subThemes,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ).copyWith(
+        fontFamilyFallback: memoFontFallbacks,
         iconTheme: IconThemeData(
           size: AppIconSizes.medium,
           color: darkColorScheme.onSurfaceVariant,

--- a/lib/core/theme/typography.dart
+++ b/lib/core/theme/typography.dart
@@ -1,31 +1,173 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-final String primaryFontFamily = GoogleFonts.notoSansJp().fontFamily!;
+enum AppFontScale {
+  small,
+  normal,
+  large;
+
+  double get factor {
+    switch (this) {
+      case AppFontScale.small:
+        return 0.94;
+      case AppFontScale.normal:
+        return 1.0;
+      case AppFontScale.large:
+        return 1.08;
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case AppFontScale.small:
+        return 'Small';
+      case AppFontScale.normal:
+        return 'Normal';
+      case AppFontScale.large:
+        return 'Large';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case AppFontScale.small:
+        return 'コンパクトに表示して情報量を重視';
+      case AppFontScale.normal:
+        return '標準の文字サイズでバランス良く表示';
+      case AppFontScale.large:
+        return 'ゆったりとした文字サイズで読みやすく';
+    }
+  }
+}
+
+final String japaneseFontFamily = GoogleFonts.notoSansJp().fontFamily!;
+final String primaryFontFamily = GoogleFonts.inter().fontFamily!;
+final List<String> memoFontFallbacks = [japaneseFontFamily];
 
 TextTheme _baseTextTheme(Brightness brightness) {
   final material2021 = Typography.material2021();
   return brightness == Brightness.dark ? material2021.white : material2021.black;
 }
 
-TextTheme _applyJapaneseFont(TextTheme base) {
-  final notoSans = GoogleFonts.notoSansJpTextTheme(base);
-  return notoSans.copyWith(
-    displayLarge: notoSans.displayLarge?.copyWith(fontWeight: FontWeight.w700),
-    displayMedium: notoSans.displayMedium?.copyWith(fontWeight: FontWeight.w700),
-    displaySmall: notoSans.displaySmall?.copyWith(fontWeight: FontWeight.w700),
-    headlineLarge: notoSans.headlineLarge?.copyWith(fontWeight: FontWeight.w700),
-    headlineMedium: notoSans.headlineMedium?.copyWith(fontWeight: FontWeight.w700),
-    headlineSmall: notoSans.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
-    titleLarge: notoSans.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-    titleMedium: notoSans.titleMedium?.copyWith(fontWeight: FontWeight.w600),
-    titleSmall: notoSans.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-    bodyLarge: notoSans.bodyLarge?.copyWith(height: 1.6),
-    bodyMedium: notoSans.bodyMedium?.copyWith(height: 1.6),
-    bodySmall: notoSans.bodySmall?.copyWith(height: 1.6),
+TextTheme _applyMemoTypography(TextTheme base, AppFontScale scale) {
+  final interTheme = GoogleFonts.interTextTheme(base);
+  final notoSans = GoogleFonts.notoSansJpTextTheme(interTheme);
+  final withFallback = notoSans.apply(
+    fontFamily: primaryFontFamily,
+    fontFamilyFallback: memoFontFallbacks,
   );
+
+  TextStyle? _soften(
+    TextStyle? style, {
+    required FontWeight fontWeight,
+    required double height,
+    double? letterSpacing,
+  }) {
+    return style?.copyWith(
+      fontWeight: fontWeight,
+      height: height,
+      letterSpacing: letterSpacing,
+      leadingDistribution: TextLeadingDistribution.even,
+    );
+  }
+
+  final tuned = withFallback.copyWith(
+    displayLarge: _soften(
+      withFallback.displayLarge,
+      fontWeight: FontWeight.w600,
+      height: 1.15,
+      letterSpacing: -0.25,
+    ),
+    displayMedium: _soften(
+      withFallback.displayMedium,
+      fontWeight: FontWeight.w600,
+      height: 1.16,
+      letterSpacing: -0.2,
+    ),
+    displaySmall: _soften(
+      withFallback.displaySmall,
+      fontWeight: FontWeight.w600,
+      height: 1.2,
+      letterSpacing: -0.1,
+    ),
+    headlineLarge: _soften(
+      withFallback.headlineLarge,
+      fontWeight: FontWeight.w600,
+      height: 1.2,
+      letterSpacing: -0.08,
+    ),
+    headlineMedium: _soften(
+      withFallback.headlineMedium,
+      fontWeight: FontWeight.w600,
+      height: 1.22,
+      letterSpacing: -0.04,
+    ),
+    headlineSmall: _soften(
+      withFallback.headlineSmall,
+      fontWeight: FontWeight.w600,
+      height: 1.22,
+    ),
+    titleLarge: _soften(
+      withFallback.titleLarge,
+      fontWeight: FontWeight.w600,
+      height: 1.26,
+      letterSpacing: -0.02,
+    ),
+    titleMedium: _soften(
+      withFallback.titleMedium,
+      fontWeight: FontWeight.w600,
+      height: 1.28,
+      letterSpacing: -0.01,
+    ),
+    titleSmall: _soften(
+      withFallback.titleSmall,
+      fontWeight: FontWeight.w600,
+      height: 1.3,
+      letterSpacing: 0.01,
+    ),
+    bodyLarge: _soften(
+      withFallback.bodyLarge,
+      fontWeight: FontWeight.w500,
+      height: 1.7,
+      letterSpacing: 0.01,
+    ),
+    bodyMedium: _soften(
+      withFallback.bodyMedium,
+      fontWeight: FontWeight.w500,
+      height: 1.68,
+      letterSpacing: 0.01,
+    ),
+    bodySmall: _soften(
+      withFallback.bodySmall,
+      fontWeight: FontWeight.w500,
+      height: 1.6,
+      letterSpacing: 0.02,
+    ),
+    labelLarge: _soften(
+      withFallback.labelLarge,
+      fontWeight: FontWeight.w600,
+      height: 1.4,
+      letterSpacing: 0.08,
+    ),
+    labelMedium: _soften(
+      withFallback.labelMedium,
+      fontWeight: FontWeight.w600,
+      height: 1.4,
+      letterSpacing: 0.08,
+    ),
+    labelSmall: _soften(
+      withFallback.labelSmall,
+      fontWeight: FontWeight.w600,
+      height: 1.4,
+      letterSpacing: 0.1,
+    ),
+  );
+
+  return tuned.apply(fontSizeFactor: scale.factor);
 }
 
-TextTheme lightTextTheme() => _applyJapaneseFont(_baseTextTheme(Brightness.light));
+TextTheme lightTextTheme(AppFontScale scale) =>
+    _applyMemoTypography(_baseTextTheme(Brightness.light), scale);
 
-TextTheme darkTextTheme() => _applyJapaneseFont(_baseTextTheme(Brightness.dark));
+TextTheme darkTextTheme(AppFontScale scale) =>
+    _applyMemoTypography(_baseTextTheme(Brightness.dark), scale);

--- a/lib/features/settings/settings_feature.dart
+++ b/lib/features/settings/settings_feature.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../core/providers/profile_providers.dart';
+import '../../core/providers/settings_providers.dart';
 import '../../core/widgets/app_card.dart';
 import '../../core/widgets/app_page.dart';
 import '../../core/widgets/section_header.dart';
@@ -73,6 +74,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
             subtitle: '通知・テーマ・データ管理',
             icon: AppIcons.palette,
             children: [
+              const _FontScaleTile(),
               _SettingsTile(
                 icon: AppIcons.notifications,
                 title: '通知',
@@ -339,6 +341,105 @@ class _StatusChip extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _FontScaleTile extends ConsumerWidget {
+  const _FontScaleTile();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final fontScale = ref.watch(fontScaleProvider);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: colorScheme.primary.withOpacity(0.08),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(10),
+                  child: Icon(AppIcons.text, color: colorScheme.primary),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '文字サイズ',
+                      style: textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Small / Normal / Large から選択できます',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 10,
+            runSpacing: 8,
+            children: [
+              for (final option in AppFontScale.values)
+                ChoiceChip(
+                  label: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 2),
+                    child: Text(
+                      option.label,
+                      style: textTheme.labelLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: fontScale == option
+                            ? colorScheme.onPrimary
+                            : colorScheme.onSurface,
+                      ),
+                    ),
+                  ),
+                  selected: fontScale == option,
+                  onSelected: (_) =>
+                      ref.read(fontScaleProvider.notifier).update(option),
+                  selectedColor: colorScheme.primary,
+                  backgroundColor:
+                      colorScheme.surfaceVariant.withOpacity(0.5),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  side: BorderSide(
+                    color: fontScale == option
+                        ? colorScheme.primary
+                        : colorScheme.outlineVariant,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            fontScale.description,
+            style: textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'core/routing/app_router.dart';
+import 'core/providers/settings_providers.dart';
 import 'core/services/supabase_service.dart';
 import 'core/theme/theme.dart';
 
@@ -33,11 +34,12 @@ class BookMemolyApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final router = ref.watch(appRouterProvider);
+    final fontScale = ref.watch(fontScaleProvider);
 
     return MaterialApp.router(
       title: 'Book Memoly',
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
+      theme: AppTheme.lightTheme(fontScale),
+      darkTheme: AppTheme.darkTheme(fontScale),
       themeMode: ThemeMode.system,
       routerConfig: router,
     );

--- a/lib/shared/constants/app_icons.dart
+++ b/lib/shared/constants/app_icons.dart
@@ -48,6 +48,7 @@ class AppIcons {
   static const IconData notifications = Symbols.notifications_active_rounded;
   static const IconData darkMode = Symbols.dark_mode_rounded;
   static const IconData palette = Symbols.palette_rounded;
+  static const IconData text = Symbols.text_fields_rounded;
   static const IconData export = Symbols.sim_card_download_rounded;
   static const IconData shield = Symbols.shield_person_rounded;
   static const IconData warning = Symbols.warning_rounded;


### PR DESCRIPTION
## Summary
- redesign typography to use Inter with Noto Sans JP fallbacks and tuned line heights
- apply configurable font scaling across light and dark themes
- add a settings control to pick small/normal/large font sizes with persistence

## Testing
- Not run (Flutter SDK unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242fe68ff08329b43cfb262505becc)