### PR TITLE
Add Supabase sync for local data backup

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -541,6 +541,14 @@ class ActionDao {
         .toList();
   }
 
+  Future<List<ActionRow>> getAllActions(String userId) async {
+    final actions = List<ActionRow>.from(
+      db._actionRows.where((action) => action.userId == userId),
+    )..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+
+    return actions;
+  }
+
   Future<List<ActionRow>> getActionsForBook(String userId, int bookId) async {
     return db._actionRows
         .where((action) => action.userId == userId && action.bookId == bookId)

--- a/lib/core/providers/sync_providers.dart
+++ b/lib/core/providers/sync_providers.dart
@@ -1,0 +1,32 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../providers/auth_providers.dart';
+import '../providers/database_providers.dart';
+import '../services/supabase_service.dart';
+import '../services/sync_service.dart';
+
+final connectivityProvider = Provider<Connectivity>((ref) {
+  return Connectivity();
+});
+
+final supabaseSyncServiceProvider = Provider<SupabaseSyncService?>((ref) {
+  final supabase = ref.watch(supabaseServiceProvider);
+  final userId = ref.watch(currentUserIdProvider);
+
+  if (supabase == null || userId == null) {
+    return null;
+  }
+
+  final repository = ref.watch(localDatabaseRepositoryProvider);
+  final connectivity = ref.watch(connectivityProvider);
+
+  final service = SupabaseSyncService(
+    client: supabase.client,
+    repository: repository,
+    connectivity: connectivity,
+  );
+
+  ref.onDispose(service.dispose);
+  return service;
+});

--- a/lib/core/repositories/local_database_repository.dart
+++ b/lib/core/repositories/local_database_repository.dart
@@ -59,6 +59,14 @@ class LocalDatabaseRepository {
     return actions.getActionsForBook(userId, bookId);
   }
 
+  Future<List<ActionRow>> getAllActions() {
+    return actions.getAllActions(userId);
+  }
+
+  Future<List<ReadingLogRow>> getAllReadingLogs() {
+    return readingLogs.getAllLogs(userId);
+  }
+
   Future<void> setTagsForBook({
     required int bookId,
     required List<int> tagIds,

--- a/lib/core/services/sync_service.dart
+++ b/lib/core/services/sync_service.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../repositories/local_database_repository.dart';
+
+class SupabaseSyncService {
+  SupabaseSyncService({
+    required SupabaseClient client,
+    required LocalDatabaseRepository repository,
+    Connectivity? connectivity,
+  })  : _client = client,
+        _repository = repository,
+        _connectivity = connectivity ?? Connectivity() {
+    _connectivitySubscription =
+        _connectivity.onConnectivityChanged.listen((status) {
+      final isConnected = status != ConnectivityResult.none;
+      if (isConnected) {
+        syncIfConnected();
+      }
+    });
+  }
+
+  static const _bookTable = 'books';
+  static const _noteTable = 'notes';
+  static const _actionTable = 'actions';
+  static const _readingLogTable = 'reading_logs';
+
+  final SupabaseClient _client;
+  final LocalDatabaseRepository _repository;
+  final Connectivity _connectivity;
+  StreamSubscription<ConnectivityResult>? _connectivitySubscription;
+  bool _syncInProgress = false;
+
+  String get _userId => _repository.userId;
+
+  Future<void> dispose() async {
+    await _connectivitySubscription?.cancel();
+  }
+
+  Future<void> syncIfConnected() async {
+    if (_syncInProgress) {
+      return;
+    }
+
+    final hasConnection = await _hasNetworkConnection();
+    if (!hasConnection) {
+      return;
+    }
+
+    _syncInProgress = true;
+    try {
+      await Future.wait([
+        _syncBooks(),
+        _syncNotes(),
+        _syncActions(),
+        _syncReadingLogs(),
+      ]);
+    } catch (error, stackTrace) {
+      debugPrint('Supabase sync failed: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          context: ErrorDescription('Supabase sync failed'),
+        ),
+      );
+    } finally {
+      _syncInProgress = false;
+    }
+  }
+
+  Future<bool> _hasNetworkConnection() async {
+    final status = await _connectivity.checkConnectivity();
+    return status != ConnectivityResult.none;
+  }
+
+  Future<Map<int, DateTime>> _fetchRemoteUpdatedAt(String table) async {
+    final response = await _client
+        .from(table)
+        .select('local_id, updated_at')
+        .eq('user_id', _userId);
+
+    final updatedAtMap = <int, DateTime>{};
+    for (final item in response) {
+      final localId = item['local_id'];
+      final updatedAt = item['updated_at'];
+      if (localId is int && updatedAt is String) {
+        final parsed = DateTime.tryParse(updatedAt);
+        if (parsed != null) {
+          updatedAtMap[localId] = parsed.toUtc();
+        }
+      }
+    }
+    return updatedAtMap;
+  }
+
+  Future<void> _syncBooks() async {
+    final localBooks = await _repository.getAllBooks();
+    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_bookTable);
+
+    final payload = localBooks.where((book) {
+      final remoteUpdated = remoteUpdatedAt[book.id];
+      return remoteUpdated == null ||
+          book.updatedAt.toUtc().isAfter(remoteUpdated);
+    }).map((book) {
+      return {
+        'local_id': book.id,
+        'user_id': _userId,
+        'google_books_id': book.googleBooksId,
+        'title': book.title,
+        'authors': book.authors,
+        'description': book.description,
+        'thumbnail_url': book.thumbnailUrl,
+        'published_date': book.publishedDate,
+        'page_count': book.pageCount,
+        'status': book.status,
+        'started_at': book.startedAt?.toUtc().toIso8601String(),
+        'finished_at': book.finishedAt?.toUtc().toIso8601String(),
+        'created_at': book.createdAt.toUtc().toIso8601String(),
+        'updated_at': book.updatedAt.toUtc().toIso8601String(),
+      };
+    }).toList();
+
+    if (payload.isEmpty) {
+      return;
+    }
+
+    await _client
+        .from(_bookTable)
+        .upsert(payload, onConflict: 'user_id,local_id');
+  }
+
+  Future<void> _syncNotes() async {
+    final notes = await _repository.getAllNotes();
+    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_noteTable);
+
+    final payload = notes.where((note) {
+      final remoteUpdated = remoteUpdatedAt[note.id];
+      return remoteUpdated == null ||
+          note.updatedAt.toUtc().isAfter(remoteUpdated);
+    }).map((note) {
+      return {
+        'local_id': note.id,
+        'user_id': _userId,
+        'book_id': note.bookId,
+        'content': note.content,
+        'page_number': note.pageNumber,
+        'created_at': note.createdAt.toUtc().toIso8601String(),
+        'updated_at': note.updatedAt.toUtc().toIso8601String(),
+      };
+    }).toList();
+
+    if (payload.isEmpty) {
+      return;
+    }
+
+    await _client
+        .from(_noteTable)
+        .upsert(payload, onConflict: 'user_id,local_id');
+  }
+
+  Future<void> _syncActions() async {
+    final actions = await _repository.getAllActions();
+    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_actionTable);
+
+    final payload = actions.where((action) {
+      final remoteUpdated = remoteUpdatedAt[action.id];
+      return remoteUpdated == null ||
+          action.updatedAt.toUtc().isAfter(remoteUpdated);
+    }).map((action) {
+      return {
+        'local_id': action.id,
+        'user_id': _userId,
+        'book_id': action.bookId,
+        'note_id': action.noteId,
+        'title': action.title,
+        'description': action.description,
+        'due_date': action.dueDate?.toUtc().toIso8601String(),
+        'remind_at': action.remindAt?.toUtc().toIso8601String(),
+        'status': action.status,
+        'created_at': action.createdAt.toUtc().toIso8601String(),
+        'updated_at': action.updatedAt.toUtc().toIso8601String(),
+      };
+    }).toList();
+
+    if (payload.isEmpty) {
+      return;
+    }
+
+    await _client
+        .from(_actionTable)
+        .upsert(payload, onConflict: 'user_id,local_id');
+  }
+
+  Future<void> _syncReadingLogs() async {
+    final logs = await _repository.getAllReadingLogs();
+    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_readingLogTable);
+
+    final payload = logs.where((log) {
+      final remoteUpdated = remoteUpdatedAt[log.id];
+      return remoteUpdated == null ||
+          log.updatedAt.toUtc().isAfter(remoteUpdated);
+    }).map((log) {
+      return {
+        'local_id': log.id,
+        'user_id': _userId,
+        'book_id': log.bookId,
+        'start_page': log.startPage,
+        'end_page': log.endPage,
+        'duration_minutes': log.durationMinutes,
+        'logged_at': log.loggedAt.toUtc().toIso8601String(),
+        'created_at': log.createdAt.toUtc().toIso8601String(),
+        'updated_at': log.updatedAt.toUtc().toIso8601String(),
+      };
+    }).toList();
+
+    if (payload.isEmpty) {
+      return;
+    }
+
+    await _client
+        .from(_readingLogTable)
+        .upsert(payload, onConflict: 'user_id,local_id');
+  }
+}

--- a/lib/features/home/home_feature.dart
+++ b/lib/features/home/home_feature.dart
@@ -9,6 +9,7 @@ import '../../core/models/book.dart';
 import '../../core/providers/auth_providers.dart';
 import '../../core/providers/database_providers.dart';
 import '../../core/providers/profile_providers.dart';
+import '../../core/providers/sync_providers.dart';
 import '../../core/repositories/local_database_repository.dart';
 import '../../core/widgets/app_card.dart';
 import '../../core/widgets/app_navigation_bar.dart';
@@ -77,11 +78,27 @@ class BookshelfNotifier extends StateNotifier<BookshelfState> {
   }
 }
 
-class HomePage extends ConsumerWidget {
+class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends ConsumerState<HomePage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_startSync);
+  }
+
+  Future<void> _startSync() async {
+    final syncService = ref.read(supabaseSyncServiceProvider);
+    await syncService?.syncIfConnected();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final bookshelfState = ref.watch(bookshelfNotifierProvider);
 
     return AppPage(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,9 @@ dependencies:
   # Supabase
   supabase_flutter: ^2.0.0
 
+  # Connectivity
+  connectivity_plus: ^6.0.5
+
   # Utilities
   cupertino_icons: ^1.0.6
   shared_preferences: ^2.2.2


### PR DESCRIPTION
## Summary
- add a Supabase sync service that upserts books, notes, actions, and reading logs using updated_at based diffs
- provide Riverpod wiring and home page trigger to run sync when the app loads and connectivity is available
- add connectivity_plus dependency and repository helpers for retrieving full datasets

## Testing
- not run (Flutter SDK not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250ea5c40083299f07f5adc12f9dac)