### PR TITLE
Add Supabase remote synchronization to local database

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -441,6 +441,22 @@ class BookDao {
     db._notifyBooksChanged();
     return 1;
   }
+
+  Future<void> upsertFromRemote(BookRow row) async {
+    final index = db._bookRows
+        .indexWhere((book) => book.id == row.id && book.userId == row.userId);
+    if (index == -1) {
+      db._bookRows.add(row);
+    } else {
+      db._bookRows[index] = row;
+    }
+
+    if (db._bookId < row.id) {
+      db._bookId = row.id;
+    }
+
+    db._notifyBooksChanged();
+  }
 }
 
 class NoteDao {
@@ -507,6 +523,20 @@ class NoteDao {
         .removeWhere((note) => note.id == noteId && note.userId == userId);
     db._noteTagRows.removeWhere((row) => row.noteId == noteId);
     return beforeLength == db._noteRows.length ? 0 : 1;
+  }
+
+  Future<void> upsertFromRemote(NoteRow row) async {
+    final index = db._noteRows
+        .indexWhere((note) => note.id == row.id && note.userId == row.userId);
+    if (index == -1) {
+      db._noteRows.add(row);
+    } else {
+      db._noteRows[index] = row;
+    }
+
+    if (db._noteId < row.id) {
+      db._noteId = row.id;
+    }
   }
 }
 
@@ -595,6 +625,22 @@ class ActionDao {
         (action) => action.id == actionId && action.userId == userId);
     return beforeLength == db._actionRows.length ? 0 : 1;
   }
+
+  Future<void> upsertFromRemote(ActionRow row) async {
+    final index = db._actionRows.indexWhere(
+      (action) => action.id == row.id && action.userId == row.userId,
+    );
+
+    if (index == -1) {
+      db._actionRows.add(row);
+    } else {
+      db._actionRows[index] = row;
+    }
+
+    if (db._actionId < row.id) {
+      db._actionId = row.id;
+    }
+  }
 }
 
 class ReadingLogDao {
@@ -629,6 +675,22 @@ class ReadingLogDao {
       db._readingLogRows.where((log) => log.userId == userId),
     )..sort((a, b) => b.loggedAt.compareTo(a.loggedAt));
     return logs;
+  }
+
+  Future<void> upsertFromRemote(ReadingLogRow row) async {
+    final index = db._readingLogRows.indexWhere(
+      (log) => log.id == row.id && log.userId == row.userId,
+    );
+
+    if (index == -1) {
+      db._readingLogRows.add(row);
+    } else {
+      db._readingLogRows[index] = row;
+    }
+
+    if (db._readingLogId < row.id) {
+      db._readingLogId = row.id;
+    }
   }
 }
 

--- a/lib/core/repositories/local_database_repository.dart
+++ b/lib/core/repositories/local_database_repository.dart
@@ -67,6 +67,22 @@ class LocalDatabaseRepository {
     return readingLogs.getAllLogs(userId);
   }
 
+  Future<void> upsertBookFromRemote(BookRow book) async {
+    await books.upsertFromRemote(book);
+  }
+
+  Future<void> upsertNoteFromRemote(NoteRow note) async {
+    await notes.upsertFromRemote(note);
+  }
+
+  Future<void> upsertActionFromRemote(ActionRow action) async {
+    await actions.upsertFromRemote(action);
+  }
+
+  Future<void> upsertReadingLogFromRemote(ReadingLogRow log) async {
+    await readingLogs.upsertFromRemote(log);
+  }
+
   Future<void> setTagsForBook({
     required int bookId,
     required List<int> tagIds,

--- a/lib/core/services/sync_service.dart
+++ b/lib/core/services/sync_service.dart
@@ -4,6 +4,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../database/app_database.dart';
 import '../repositories/local_database_repository.dart';
 
 class SupabaseSyncService {
@@ -77,31 +78,60 @@ class SupabaseSyncService {
     return status != ConnectivityResult.none;
   }
 
-  Future<Map<int, DateTime>> _fetchRemoteUpdatedAt(String table) async {
-    final response = await _client
-        .from(table)
-        .select('local_id, updated_at')
-        .eq('user_id', _userId);
+  DateTime? _parseDateTime(dynamic value) {
+    if (value is String) {
+      return DateTime.tryParse(value)?.toUtc();
+    }
 
+    if (value is DateTime) {
+      return value.toUtc();
+    }
+
+    return null;
+  }
+
+  int? _parseInt(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+
+    if (value is num) {
+      return value.toInt();
+    }
+
+    return null;
+  }
+
+  Map<int, DateTime> _buildRemoteUpdatedAtMap(List<dynamic> rows) {
     final updatedAtMap = <int, DateTime>{};
-    for (final item in response) {
-      final localId = item['local_id'];
-      final updatedAt = item['updated_at'];
-      if (localId is int && updatedAt is String) {
-        final parsed = DateTime.tryParse(updatedAt);
-        if (parsed != null) {
-          updatedAtMap[localId] = parsed.toUtc();
-        }
+
+    for (final row in rows) {
+      final localId = row['local_id'];
+      final updatedAt = _parseDateTime(row['updated_at']);
+
+      if (localId is int && updatedAt != null) {
+        updatedAtMap[localId] = updatedAt;
       }
     }
+
     return updatedAtMap;
   }
 
   Future<void> _syncBooks() async {
-    final localBooks = await _repository.getAllBooks();
-    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_bookTable);
+    final remoteRows = await _client
+        .from(_bookTable)
+        .select<List<Map<String, dynamic>>>('*')
+        .eq('user_id', _userId);
 
-    final payload = localBooks.where((book) {
+    final localBooks = await _repository.getAllBooks();
+    final localById = {for (final book in localBooks) book.id: book};
+
+    await _applyRemoteBooks(remoteRows, localById);
+
+    final mergedBooks = await _repository.getAllBooks();
+    final remoteUpdatedAt = _buildRemoteUpdatedAtMap(remoteRows);
+
+    final payload = mergedBooks.where((book) {
       final remoteUpdated = remoteUpdatedAt[book.id];
       return remoteUpdated == null ||
           book.updatedAt.toUtc().isAfter(remoteUpdated);
@@ -133,14 +163,68 @@ class SupabaseSyncService {
         .upsert(payload, onConflict: 'user_id,local_id');
   }
 
-  Future<void> _syncNotes() async {
-    final notes = await _repository.getAllNotes();
-    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_noteTable);
+  Future<void> _applyRemoteBooks(
+    List<dynamic> remoteRows,
+    Map<int, BookRow> localById,
+  ) async {
+    for (final row in remoteRows) {
+      final localId = row['local_id'];
+      final googleBooksId = row['google_books_id'];
+      final title = row['title'];
+      final updatedAt = _parseDateTime(row['updated_at']);
 
-    final payload = notes.where((note) {
+      if (localId is! int ||
+          googleBooksId is! String ||
+          title is! String ||
+          updatedAt == null) {
+        continue;
+      }
+
+      final localUpdated = localById[localId]?.updatedAt.toUtc();
+      if (localUpdated != null && !updatedAt.isAfter(localUpdated)) {
+        continue;
+      }
+
+      final createdAt = _parseDateTime(row['created_at']) ?? updatedAt;
+
+      final book = BookRow(
+        id: localId,
+        userId: _userId,
+        googleBooksId: googleBooksId,
+        title: title,
+        authors: row['authors'] as String?,
+        description: row['description'] as String?,
+        thumbnailUrl: row['thumbnail_url'] as String?,
+        publishedDate: row['published_date'] as String?,
+        pageCount: _parseInt(row['page_count']),
+        status: _parseInt(row['status']) ?? 0,
+        startedAt: _parseDateTime(row['started_at']),
+        finishedAt: _parseDateTime(row['finished_at']),
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      await _repository.upsertBookFromRemote(book);
+    }
+  }
+
+  Future<void> _syncNotes() async {
+    final remoteRows = await _client
+        .from(_noteTable)
+        .select<List<Map<String, dynamic>>>('*')
+        .eq('user_id', _userId);
+
+    final localNotes = await _repository.getAllNotes();
+    final localById = {for (final note in localNotes) note.id: note};
+
+    await _applyRemoteNotes(remoteRows, localById);
+
+    final mergedNotes = await _repository.getAllNotes();
+    final remoteUpdatedAt = _buildRemoteUpdatedAtMap(remoteRows);
+
+    final payload = mergedNotes.where((note) {
       final remoteUpdated = remoteUpdatedAt[note.id];
-      return remoteUpdated == null ||
-          note.updatedAt.toUtc().isAfter(remoteUpdated);
+      return remoteUpdated == null || note.updatedAt.toUtc().isAfter(remoteUpdated);
     }).map((note) {
       return {
         'local_id': note.id,
@@ -162,11 +246,59 @@ class SupabaseSyncService {
         .upsert(payload, onConflict: 'user_id,local_id');
   }
 
-  Future<void> _syncActions() async {
-    final actions = await _repository.getAllActions();
-    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_actionTable);
+  Future<void> _applyRemoteNotes(
+    List<dynamic> remoteRows,
+    Map<int, NoteRow> localById,
+  ) async {
+    for (final row in remoteRows) {
+      final localId = row['local_id'];
+      final bookId = row['book_id'];
+      final content = row['content'];
+      final updatedAt = _parseDateTime(row['updated_at']);
 
-    final payload = actions.where((action) {
+      if (localId is! int ||
+          bookId is! int ||
+          content is! String ||
+          updatedAt == null) {
+        continue;
+      }
+
+      final localUpdated = localById[localId]?.updatedAt.toUtc();
+      if (localUpdated != null && !updatedAt.isAfter(localUpdated)) {
+        continue;
+      }
+
+      final createdAt = _parseDateTime(row['created_at']) ?? updatedAt;
+
+      final note = NoteRow(
+        id: localId,
+        userId: _userId,
+        bookId: bookId,
+        content: content,
+        pageNumber: _parseInt(row['page_number']),
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      await _repository.upsertNoteFromRemote(note);
+    }
+  }
+
+  Future<void> _syncActions() async {
+    final remoteRows = await _client
+        .from(_actionTable)
+        .select<List<Map<String, dynamic>>>('*')
+        .eq('user_id', _userId);
+
+    final localActions = await _repository.getAllActions();
+    final localById = {for (final action in localActions) action.id: action};
+
+    await _applyRemoteActions(remoteRows, localById);
+
+    final mergedActions = await _repository.getAllActions();
+    final remoteUpdatedAt = _buildRemoteUpdatedAtMap(remoteRows);
+
+    final payload = mergedActions.where((action) {
       final remoteUpdated = remoteUpdatedAt[action.id];
       return remoteUpdated == null ||
           action.updatedAt.toUtc().isAfter(remoteUpdated);
@@ -195,14 +327,61 @@ class SupabaseSyncService {
         .upsert(payload, onConflict: 'user_id,local_id');
   }
 
-  Future<void> _syncReadingLogs() async {
-    final logs = await _repository.getAllReadingLogs();
-    final remoteUpdatedAt = await _fetchRemoteUpdatedAt(_readingLogTable);
+  Future<void> _applyRemoteActions(
+    List<dynamic> remoteRows,
+    Map<int, ActionRow> localById,
+  ) async {
+    for (final row in remoteRows) {
+      final localId = row['local_id'];
+      final title = row['title'];
+      final updatedAt = _parseDateTime(row['updated_at']);
 
-    final payload = logs.where((log) {
+      if (localId is! int || title is! String || updatedAt == null) {
+        continue;
+      }
+
+      final localUpdated = localById[localId]?.updatedAt.toUtc();
+      if (localUpdated != null && !updatedAt.isAfter(localUpdated)) {
+        continue;
+      }
+
+      final createdAt = _parseDateTime(row['created_at']) ?? updatedAt;
+
+      final action = ActionRow(
+        id: localId,
+        userId: _userId,
+        bookId: _parseInt(row['book_id']),
+        noteId: _parseInt(row['note_id']),
+        title: title,
+        description: row['description'] as String?,
+        dueDate: _parseDateTime(row['due_date']),
+        remindAt: _parseDateTime(row['remind_at']),
+        status: row['status'] as String? ?? 'pending',
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      await _repository.upsertActionFromRemote(action);
+    }
+  }
+
+  Future<void> _syncReadingLogs() async {
+    final remoteRows = await _client
+        .from(_readingLogTable)
+        .select<List<Map<String, dynamic>>>('*')
+        .eq('user_id', _userId);
+
+    final localLogs = await _repository.getAllReadingLogs();
+    final localById = {for (final log in localLogs) log.id: log};
+
+    await _applyRemoteReadingLogs(remoteRows, localById);
+
+    final mergedLogs = await _repository.getAllReadingLogs();
+    final remoteUpdatedAt = _buildRemoteUpdatedAtMap(remoteRows);
+
+    final payload = mergedLogs.where((log) {
       final remoteUpdated = remoteUpdatedAt[log.id];
-      return remoteUpdated == null ||
-          log.updatedAt.toUtc().isAfter(remoteUpdated);
+      return remoteUpdated == null || log.updatedAt.toUtc().isAfter(remoteUpdated);
     }).map((log) {
       return {
         'local_id': log.id,
@@ -224,5 +403,41 @@ class SupabaseSyncService {
     await _client
         .from(_readingLogTable)
         .upsert(payload, onConflict: 'user_id,local_id');
+  }
+
+  Future<void> _applyRemoteReadingLogs(
+    List<dynamic> remoteRows,
+    Map<int, ReadingLogRow> localById,
+  ) async {
+    for (final row in remoteRows) {
+      final localId = row['local_id'];
+      final bookId = row['book_id'];
+      final updatedAt = _parseDateTime(row['updated_at']);
+
+      if (localId is! int || bookId is! int || updatedAt == null) {
+        continue;
+      }
+
+      final localUpdated = localById[localId]?.updatedAt.toUtc();
+      if (localUpdated != null && !updatedAt.isAfter(localUpdated)) {
+        continue;
+      }
+
+      final createdAt = _parseDateTime(row['created_at']) ?? updatedAt;
+
+      final log = ReadingLogRow(
+        id: localId,
+        userId: _userId,
+        bookId: bookId,
+        startPage: _parseInt(row['start_page']),
+        endPage: _parseInt(row['end_page']),
+        durationMinutes: _parseInt(row['duration_minutes']),
+        loggedAt: _parseDateTime(row['logged_at']) ?? updatedAt,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+      await _repository.upsertReadingLogFromRemote(log);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add repository and DAO helpers to upsert records from Supabase payloads
- extend the Supabase sync service to merge remote updates into the local database before pushing changes
- normalize Supabase payload parsing for dates and numeric fields to resolve conflicts consistently

## Testing
- Not run (dart command unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925126d6de083298b5ae80315fa52d0)