### PR TITLE
Add reading style analytics to statistics page

### DIFF
--- a/lib/shared/constants/app_icons.dart
+++ b/lib/shared/constants/app_icons.dart
@@ -59,6 +59,14 @@ class AppIcons {
   static const IconData calendarViewWeek = Symbols.calendar_view_week_rounded;
   static const IconData calendarMonth = Symbols.calendar_month_rounded;
   static const IconData speed = Symbols.speed_rounded;
+  static const IconData event = Symbols.event_rounded;
+  static const IconData schedule = Symbols.schedule_rounded;
+  static const IconData donutSmall = Symbols.donut_small_rounded;
+  static const IconData trendingFlat = Symbols.trending_flat_rounded;
+  static const IconData repeat = Symbols.repeat_rounded;
+  static const IconData leaderboard = Symbols.leaderboard_rounded;
+  static const IconData beachAccess = Symbols.beach_access_rounded;
+  static const IconData infinity = Symbols.all_inclusive_rounded;
 }
 
 class AppIconSizes {


### PR DESCRIPTION
## Summary
- add monthly/all toggle for statistics and compute detailed snapshots from reading logs
- visualize reading patterns with new speed, best time, streak, and genre breakdown sections using charts
- extend shared icon set for the added analytics UI elements

## Testing
- Not run (tooling unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257096918c83298b26740c6e2ad793)