### PR TITLE
Add daily reading reminders and reading dashboard

### DIFF
--- a/lib/core/providers/notification_providers.dart
+++ b/lib/core/providers/notification_providers.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../services/notification_service.dart';
+
+class NotificationSettingsState {
+  const NotificationSettingsState({
+    required this.reminderEnabled,
+    required this.reminderTime,
+    required this.reflectionPromptEnabled,
+    required this.permissionGranted,
+  });
+
+  final bool reminderEnabled;
+  final TimeOfDay reminderTime;
+  final bool reflectionPromptEnabled;
+  final bool permissionGranted;
+
+  NotificationSettingsState copyWith({
+    bool? reminderEnabled,
+    TimeOfDay? reminderTime,
+    bool? reflectionPromptEnabled,
+    bool? permissionGranted,
+  }) {
+    return NotificationSettingsState(
+      reminderEnabled: reminderEnabled ?? this.reminderEnabled,
+      reminderTime: reminderTime ?? this.reminderTime,
+      reflectionPromptEnabled:
+          reflectionPromptEnabled ?? this.reflectionPromptEnabled,
+      permissionGranted: permissionGranted ?? this.permissionGranted,
+    );
+  }
+}
+
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  return NotificationService();
+});
+
+final notificationSettingsNotifierProvider =
+    AsyncNotifierProvider<NotificationSettingsNotifier,
+        NotificationSettingsState>(NotificationSettingsNotifier.new);
+
+class NotificationSettingsNotifier
+    extends AsyncNotifier<NotificationSettingsState> {
+  NotificationSettingsNotifier();
+
+  static const _reminderEnabledKey = 'daily_reminder_enabled';
+  static const _reminderTimeKey = 'daily_reminder_time';
+  static const _reflectionPromptKey = 'reflection_prompt_enabled';
+
+  NotificationService get _service => ref.read(notificationServiceProvider);
+
+  @override
+  Future<NotificationSettingsState> build() async {
+    final prefs = await SharedPreferences.getInstance();
+    await _service.initialize();
+
+    final reminderEnabled = prefs.getBool(_reminderEnabledKey) ?? true;
+    final reflectionPromptEnabled = prefs.getBool(_reflectionPromptKey) ?? true;
+    final reminderTime = _parseReminderTime(
+          prefs.getString(_reminderTimeKey),
+        ) ??
+        const TimeOfDay(hour: 20, minute: 0);
+
+    final permissionGranted = await _service.ensurePermissionsGranted();
+
+    if (reminderEnabled && permissionGranted) {
+      await _service.scheduleDailyReminder(reminderTime);
+    }
+
+    return NotificationSettingsState(
+      reminderEnabled: reminderEnabled,
+      reminderTime: reminderTime,
+      reflectionPromptEnabled: reflectionPromptEnabled,
+      permissionGranted: permissionGranted,
+    );
+  }
+
+  Future<void> updateReminderEnabled(bool enabled) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    var permissionGranted = current.permissionGranted;
+
+    if (enabled) {
+      permissionGranted = await _service.ensurePermissionsGranted();
+      if (permissionGranted) {
+        await _service.scheduleDailyReminder(current.reminderTime);
+      }
+    } else {
+      await _service.cancelDailyReminder();
+    }
+
+    await prefs.setBool(_reminderEnabledKey, enabled);
+
+    state = AsyncData(
+      current.copyWith(
+        reminderEnabled: enabled,
+        permissionGranted: permissionGranted,
+      ),
+    );
+  }
+
+  Future<void> updateReminderTime(TimeOfDay time) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_reminderTimeKey, _formatTime(time));
+
+    if (current.reminderEnabled && current.permissionGranted) {
+      await _service.scheduleDailyReminder(time);
+    }
+
+    state = AsyncData(current.copyWith(reminderTime: time));
+  }
+
+  Future<void> updateReflectionPromptEnabled(bool enabled) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_reflectionPromptKey, enabled);
+
+    state = AsyncData(current.copyWith(reflectionPromptEnabled: enabled));
+  }
+
+  Future<void> triggerPostReadingPrompt() async {
+    final current = state.valueOrNull;
+    if (current == null || !current.reflectionPromptEnabled) {
+      return;
+    }
+
+    await _service.ensurePermissionsGranted();
+    await _service.showReflectionPrompt();
+  }
+
+  TimeOfDay? _parseReminderTime(String? stored) {
+    if (stored == null || !stored.contains(':')) {
+      return null;
+    }
+
+    final parts = stored.split(':');
+    if (parts.length != 2) {
+      return null;
+    }
+
+    final hour = int.tryParse(parts[0]);
+    final minute = int.tryParse(parts[1]);
+    if (hour == null || minute == null) {
+      return null;
+    }
+
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+
+  String _formatTime(TimeOfDay time) {
+    final hour = time.hour.toString().padLeft(2, '0');
+    final minute = time.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
+  }
+}

--- a/lib/core/providers/reading_activity_providers.dart
+++ b/lib/core/providers/reading_activity_providers.dart
@@ -1,0 +1,18 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../providers/database_providers.dart';
+
+final todayReadingSessionsProvider = FutureProvider<int>((ref) async {
+  final repository = ref.watch(localDatabaseRepositoryProvider);
+  final logs = await repository.getReadingLogs();
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+
+  return logs
+      .where((log) {
+        final loggedAt = log.loggedAt;
+        final logDate = DateTime(loggedAt.year, loggedAt.month, loggedAt.day);
+        return logDate == today;
+      })
+      .length;
+});

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+class NotificationService {
+  NotificationService();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  bool _initialized = false;
+
+  static const _dailyReminderId = 1;
+  static const _reflectionPromptId = 2;
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const darwinInit = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+
+    final settings = const InitializationSettings(
+      android: androidInit,
+      iOS: darwinInit,
+      macOS: darwinInit,
+    );
+
+    await _plugin.initialize(settings);
+    tz.initializeTimeZones();
+    _setLocalTimezone();
+
+    _initialized = true;
+  }
+
+  Future<bool> ensurePermissionsGranted() async {
+    await initialize();
+
+    final areEnabled = await _plugin.areNotificationsEnabled();
+    if (areEnabled ?? false) {
+      return true;
+    }
+
+    final androidPlugin =
+        _plugin.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    final macPlugin = _plugin.resolvePlatformSpecificImplementation<
+        MacOSFlutterLocalNotificationsPlugin>();
+    final iosPlugin = _plugin.resolvePlatformSpecificImplementation<
+        IOSFlutterLocalNotificationsPlugin>();
+
+    final androidGranted =
+        await androidPlugin?.requestNotificationsPermission() ?? false;
+    final iosGranted = await iosPlugin?.requestPermissions(
+          alert: true,
+          sound: true,
+          badge: true,
+        ) ??
+        false;
+    final macGranted = await macPlugin?.requestPermissions(
+          alert: true,
+          sound: true,
+          badge: true,
+        ) ??
+        false;
+
+    return androidGranted || iosGranted || macGranted;
+  }
+
+  Future<void> scheduleDailyReminder(TimeOfDay time) async {
+    await initialize();
+
+    final scheduledDate = _nextInstance(time);
+
+    await _plugin.zonedSchedule(
+      _dailyReminderId,
+      '今日の読書リマインド',
+      '少しだけでも読書を進めませんか？',
+      scheduledDate,
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          'daily_reading_reminder',
+          'Daily Reading Reminder',
+          channelDescription: '毎日の読書を習慣化するための通知',
+          importance: Importance.max,
+          priority: Priority.high,
+          visibility: NotificationVisibility.public,
+        ),
+        iOS: const DarwinNotificationDetails(),
+        macOS: const DarwinNotificationDetails(),
+      ),
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.wallClockTime,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  Future<void> cancelDailyReminder() async {
+    await initialize();
+    await _plugin.cancel(_dailyReminderId);
+  }
+
+  Future<void> showReflectionPrompt() async {
+    await initialize();
+
+    await _plugin.show(
+      _reflectionPromptId,
+      '今日の学びを書く？',
+      'メモに残すことで明日の読書がもっと楽になります。',
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          'reading_reflection',
+          'Reading Reflection',
+          channelDescription: '読書後に気づきを振り返るためのリマインド',
+          importance: Importance.high,
+          priority: Priority.high,
+        ),
+        iOS: const DarwinNotificationDetails(),
+        macOS: const DarwinNotificationDetails(),
+      ),
+    );
+  }
+
+  tz.TZDateTime _nextInstance(TimeOfDay time) {
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduled = tz.TZDateTime(
+      tz.local,
+      now.year,
+      now.month,
+      now.day,
+      time.hour,
+      time.minute,
+    );
+
+    if (!scheduled.isAfter(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+
+    return scheduled;
+  }
+
+  void _setLocalTimezone() {
+    final timeZoneName = DateTime.now().timeZoneName;
+
+    try {
+      tz.setLocalLocation(tz.getLocation(timeZoneName));
+    } catch (_) {
+      tz.setLocalLocation(tz.getLocation('Asia/Tokyo'));
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   fl_chart: ^0.69.0
+  flutter_local_notifications: ^17.2.3
 
   # Theming
   flex_color_scheme: ^8.3.1
@@ -50,6 +51,7 @@ dependencies:
   shared_preferences: ^2.2.2
   image_picker: ^1.1.2
   collection: ^1.18.0
+  timezone: ^0.9.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a notification service with daily reminders and post-reading reflection prompts plus persisted settings
- update settings and reading log screens to schedule reminders, prompt reflections, and refresh daily reading counts
- show a home dashboard card for today’s reading sessions to encourage daily habits

## Testing
- not run (flutter/dart CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692583f0ca748329a7d4be623fcbe800)