### PR TITLE
Add local notification reminders

### DIFF
--- a/lib/core/providers/notification_providers.dart
+++ b/lib/core/providers/notification_providers.dart
@@ -1,31 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/book.dart';
+import '../database/app_database.dart';
 import '../services/notification_service.dart';
+import 'database_providers.dart';
+import '../repositories/local_database_repository.dart';
+import '../routing/app_router.dart';
 
 class NotificationSettingsState {
   const NotificationSettingsState({
     required this.reminderEnabled,
     required this.reminderTime,
+    required this.reminderFrequency,
+    required this.weeklyWeekday,
+    required this.continueReminderEnabled,
+    required this.actionPlanRemindersEnabled,
     required this.reflectionPromptEnabled,
     required this.permissionGranted,
   });
 
   final bool reminderEnabled;
   final TimeOfDay reminderTime;
+  final ReminderFrequency reminderFrequency;
+  final int weeklyWeekday;
+  final bool continueReminderEnabled;
+  final bool actionPlanRemindersEnabled;
   final bool reflectionPromptEnabled;
   final bool permissionGranted;
 
   NotificationSettingsState copyWith({
     bool? reminderEnabled,
     TimeOfDay? reminderTime,
+    ReminderFrequency? reminderFrequency,
+    int? weeklyWeekday,
+    bool? continueReminderEnabled,
+    bool? actionPlanRemindersEnabled,
     bool? reflectionPromptEnabled,
     bool? permissionGranted,
   }) {
     return NotificationSettingsState(
       reminderEnabled: reminderEnabled ?? this.reminderEnabled,
       reminderTime: reminderTime ?? this.reminderTime,
+      reminderFrequency: reminderFrequency ?? this.reminderFrequency,
+      weeklyWeekday: weeklyWeekday ?? this.weeklyWeekday,
+      continueReminderEnabled:
+          continueReminderEnabled ?? this.continueReminderEnabled,
+      actionPlanRemindersEnabled:
+          actionPlanRemindersEnabled ?? this.actionPlanRemindersEnabled,
       reflectionPromptEnabled:
           reflectionPromptEnabled ?? this.reflectionPromptEnabled,
       permissionGranted: permissionGranted ?? this.permissionGranted,
@@ -47,9 +71,20 @@ class NotificationSettingsNotifier
 
   static const _reminderEnabledKey = 'daily_reminder_enabled';
   static const _reminderTimeKey = 'daily_reminder_time';
+  static const _reminderFrequencyKey = 'reading_reminder_frequency';
+  static const _weeklyWeekdayKey = 'reading_reminder_weekday';
+  static const _continueReminderKey = 'continue_reading_enabled';
+  static const _actionPlanReminderKey = 'action_plan_reminder_enabled';
   static const _reflectionPromptKey = 'reflection_prompt_enabled';
 
   NotificationService get _service => ref.read(notificationServiceProvider);
+  LocalDatabaseRepository? get _repositoryOrNull {
+    try {
+      return ref.read(localDatabaseRepositoryProvider);
+    } catch (_) {
+      return null;
+    }
+  }
 
   @override
   Future<NotificationSettingsState> build() async {
@@ -58,6 +93,15 @@ class NotificationSettingsNotifier
 
     final reminderEnabled = prefs.getBool(_reminderEnabledKey) ?? true;
     final reflectionPromptEnabled = prefs.getBool(_reflectionPromptKey) ?? true;
+    final reminderFrequency = _parseFrequency(
+          prefs.getInt(_reminderFrequencyKey),
+        ) ??
+        ReminderFrequency.daily;
+    final weeklyWeekday = prefs.getInt(_weeklyWeekdayKey) ?? DateTime.monday;
+    final continueReminderEnabled =
+        prefs.getBool(_continueReminderKey) ?? true;
+    final actionPlanRemindersEnabled =
+        prefs.getBool(_actionPlanReminderKey) ?? true;
     final reminderTime = _parseReminderTime(
           prefs.getString(_reminderTimeKey),
         ) ??
@@ -66,12 +110,32 @@ class NotificationSettingsNotifier
     final permissionGranted = await _service.ensurePermissionsGranted();
 
     if (reminderEnabled && permissionGranted) {
-      await _service.scheduleDailyReminder(reminderTime);
+      await _service.scheduleReadingReminder(
+        reminderTime,
+        frequency: reminderFrequency,
+        weeklyWeekday: weeklyWeekday,
+      );
+    }
+
+    if (continueReminderEnabled && permissionGranted) {
+      await _scheduleContinueReadingReminder(
+        time: reminderTime,
+        frequency: reminderFrequency,
+        weeklyWeekday: weeklyWeekday,
+      );
+    }
+
+    if (actionPlanRemindersEnabled && permissionGranted) {
+      await refreshActionPlanReminders();
     }
 
     return NotificationSettingsState(
       reminderEnabled: reminderEnabled,
       reminderTime: reminderTime,
+      reminderFrequency: reminderFrequency,
+      weeklyWeekday: weeklyWeekday,
+      continueReminderEnabled: continueReminderEnabled,
+      actionPlanRemindersEnabled: actionPlanRemindersEnabled,
       reflectionPromptEnabled: reflectionPromptEnabled,
       permissionGranted: permissionGranted,
     );
@@ -89,10 +153,22 @@ class NotificationSettingsNotifier
     if (enabled) {
       permissionGranted = await _service.ensurePermissionsGranted();
       if (permissionGranted) {
-        await _service.scheduleDailyReminder(current.reminderTime);
+        await _service.scheduleReadingReminder(
+          current.reminderTime,
+          frequency: current.reminderFrequency,
+          weeklyWeekday: current.weeklyWeekday,
+        );
+        if (current.continueReminderEnabled) {
+          await _scheduleContinueReadingReminder(
+            time: current.reminderTime,
+            frequency: current.reminderFrequency,
+            weeklyWeekday: current.weeklyWeekday,
+          );
+        }
       }
     } else {
       await _service.cancelDailyReminder();
+      await _service.cancelContinueReadingReminder();
     }
 
     await prefs.setBool(_reminderEnabledKey, enabled);
@@ -115,10 +191,91 @@ class NotificationSettingsNotifier
     await prefs.setString(_reminderTimeKey, _formatTime(time));
 
     if (current.reminderEnabled && current.permissionGranted) {
-      await _service.scheduleDailyReminder(time);
+      await _service.scheduleReadingReminder(
+        time,
+        frequency: current.reminderFrequency,
+        weeklyWeekday: current.weeklyWeekday,
+      );
+      if (current.continueReminderEnabled) {
+        await _scheduleContinueReadingReminder(
+          time: time,
+          frequency: current.reminderFrequency,
+          weeklyWeekday: current.weeklyWeekday,
+        );
+      }
     }
 
     state = AsyncData(current.copyWith(reminderTime: time));
+  }
+
+  Future<void> updateReminderFrequency(ReminderFrequency frequency) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_reminderFrequencyKey, frequency.index);
+
+    final newState = current.copyWith(reminderFrequency: frequency);
+    await _rescheduleReadingReminders(newState);
+
+    state = AsyncData(newState);
+  }
+
+  Future<void> updateWeeklyWeekday(int weekday) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_weeklyWeekdayKey, weekday);
+
+    final newState = current.copyWith(weeklyWeekday: weekday);
+    await _rescheduleReadingReminders(newState);
+
+    state = AsyncData(newState);
+  }
+
+  Future<void> updateContinueReminderEnabled(bool enabled) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_continueReminderKey, enabled);
+
+    if (enabled && current.permissionGranted && current.reminderEnabled) {
+      await _scheduleContinueReadingReminder(
+        time: current.reminderTime,
+        frequency: current.reminderFrequency,
+        weeklyWeekday: current.weeklyWeekday,
+      );
+    } else {
+      await _service.cancelContinueReadingReminder();
+    }
+
+    state = AsyncData(current.copyWith(continueReminderEnabled: enabled));
+  }
+
+  Future<void> updateActionPlanReminderEnabled(bool enabled) async {
+    final current = state.valueOrNull;
+    if (current == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_actionPlanReminderKey, enabled);
+
+    if (enabled) {
+      await refreshActionPlanReminders();
+    } else {
+      await _cancelAllActionPlanReminders();
+    }
+
+    state = AsyncData(current.copyWith(actionPlanRemindersEnabled: enabled));
   }
 
   Future<void> updateReflectionPromptEnabled(bool enabled) async {
@@ -141,6 +298,55 @@ class NotificationSettingsNotifier
 
     await _service.ensurePermissionsGranted();
     await _service.showReflectionPrompt();
+  }
+
+  Future<void> refreshContinueReadingReminder() async {
+    final current = state.valueOrNull;
+    if (current == null ||
+        !current.permissionGranted ||
+        !current.reminderEnabled ||
+        !current.continueReminderEnabled) {
+      return;
+    }
+
+    await _scheduleContinueReadingReminder(
+      time: current.reminderTime,
+      frequency: current.reminderFrequency,
+      weeklyWeekday: current.weeklyWeekday,
+    );
+  }
+
+  Future<void> refreshActionPlanReminders() async {
+    final current = state.valueOrNull;
+    final repository = _repositoryOrNull;
+    if (current == null || repository == null) {
+      return;
+    }
+
+    final actions = await repository.getAllActions();
+    final books = await repository.getAllBooks();
+    final bookTitleMap = {for (final book in books) book.id: book.title};
+
+    for (final action in actions) {
+      if (action.remindAt == null ||
+          !current.permissionGranted ||
+          !current.actionPlanRemindersEnabled) {
+        await _service.cancelActionPlanReminder(action.id);
+        continue;
+      }
+
+      if (action.remindAt!.isAfter(DateTime.now())) {
+        await _service.scheduleActionPlanReminder(
+          actionId: action.id,
+          actionTitle: action.title,
+          remindAt: action.remindAt!,
+          bookId: action.bookId,
+          bookTitle: bookTitleMap[action.bookId],
+        );
+      } else {
+        await _service.cancelActionPlanReminder(action.id);
+      }
+    }
   }
 
   TimeOfDay? _parseReminderTime(String? stored) {
@@ -166,5 +372,133 @@ class NotificationSettingsNotifier
     final hour = time.hour.toString().padLeft(2, '0');
     final minute = time.minute.toString().padLeft(2, '0');
     return '$hour:$minute';
+  }
+
+  ReminderFrequency? _parseFrequency(int? stored) {
+    if (stored == null) {
+      return null;
+    }
+
+    if (stored < 0 || stored >= ReminderFrequency.values.length) {
+      return null;
+    }
+
+    return ReminderFrequency.values[stored];
+  }
+
+  Future<void> _rescheduleReadingReminders(
+    NotificationSettingsState newState,
+  ) async {
+    if (!newState.permissionGranted || !newState.reminderEnabled) {
+      return;
+    }
+
+    await _service.scheduleReadingReminder(
+      newState.reminderTime,
+      frequency: newState.reminderFrequency,
+      weeklyWeekday: newState.weeklyWeekday,
+    );
+
+    if (newState.continueReminderEnabled) {
+      await _scheduleContinueReadingReminder(
+        time: newState.reminderTime,
+        frequency: newState.reminderFrequency,
+        weeklyWeekday: newState.weeklyWeekday,
+      );
+    }
+  }
+
+  Future<void> _scheduleContinueReadingReminder({
+    required TimeOfDay time,
+    required ReminderFrequency frequency,
+    required int weeklyWeekday,
+  }) async {
+    final repository = _repositoryOrNull;
+    if (repository == null) {
+      return;
+    }
+
+    final books = await repository.getAllBooks();
+    final readingBooks = books
+        .where((book) => book.status == BookStatus.reading.toDbValue)
+        .toList();
+
+    if (readingBooks.isEmpty) {
+      await _service.cancelContinueReadingReminder();
+      return;
+    }
+
+    readingBooks
+        .sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    final target = readingBooks.first;
+
+    await _service.scheduleContinueReadingReminder(
+      bookId: target.id,
+      bookTitle: target.title,
+      time: time,
+      frequency: frequency,
+      weeklyWeekday: weeklyWeekday,
+    );
+  }
+
+  Future<void> _cancelAllActionPlanReminders() async {
+    final repository = _repositoryOrNull;
+    if (repository == null) {
+      return;
+    }
+
+    final actions = await repository.getAllActions();
+    for (final action in actions) {
+      await _service.cancelActionPlanReminder(action.id);
+    }
+  }
+}
+
+final notificationPayloadProvider =
+    StateProvider<NotificationPayload?>((_) => null);
+
+final notificationNavigationProvider =
+    Provider<NotificationNavigationHandler>((ref) {
+  return NotificationNavigationHandler(ref);
+});
+
+class NotificationNavigationHandler {
+  NotificationNavigationHandler(this._ref) {
+    _setup();
+  }
+
+  final Ref _ref;
+
+  void _setup() {
+    final service = _ref.read(notificationServiceProvider);
+    service.registerSelectNotificationHandler(_onNotificationResponse);
+    _loadInitialPayload(service);
+  }
+
+  Future<void> _loadInitialPayload(NotificationService service) async {
+    final payload = await service.getLaunchPayload();
+    if (payload != null) {
+      _handlePayload(payload);
+    }
+  }
+
+  void _onNotificationResponse(NotificationResponse response) {
+    final rawPayload = response.payload;
+    if (rawPayload == null) {
+      return;
+    }
+
+    try {
+      final payload = NotificationPayload.fromJson(rawPayload);
+      _handlePayload(payload);
+    } catch (_) {
+      // Ignore malformed payloads
+    }
+  }
+
+  void _handlePayload(NotificationPayload payload) {
+    _ref.read(notificationPayloadProvider.notifier).state = payload;
+    final router = _ref.read(appRouterProvider);
+    router.go(payload.targetRoute);
   }
 }

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -126,14 +126,22 @@ final appRouterProvider = StateProvider<GoRouter>((ref) {
       ),
       GoRoute(
         path: '/actions',
-        pageBuilder: (context, state) => _buildNoTransitionPage(
-          child: const ActionPlansPage(),
-          state: state,
-        ),
+        pageBuilder: (context, state) {
+          final bookId =
+              int.tryParse(state.uri.queryParameters['bookId'] ?? '');
+          return _buildNoTransitionPage(
+            child: ActionPlansPage(initialBookId: bookId),
+            state: state,
+          );
+        },
       ),
       GoRoute(
         path: '/reading-speed',
-        builder: (context, state) => const ReadingSpeedPage(),
+        builder: (context, state) {
+          final bookId =
+              int.tryParse(state.uri.queryParameters['bookId'] ?? '');
+          return ReadingSpeedPage(initialBookId: bookId);
+        },
       ),
       GoRoute(
         path: '/statistics',

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,7 +1,77 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
+
+enum ReminderFrequency {
+  daily,
+  weekly;
+
+  String get label {
+    switch (this) {
+      case ReminderFrequency.daily:
+        return '毎日';
+      case ReminderFrequency.weekly:
+        return '毎週';
+    }
+  }
+}
+
+enum NotificationType {
+  readingReminder,
+  continueReading,
+  actionPlanDue,
+}
+
+class NotificationPayload {
+  NotificationPayload({
+    required this.type,
+    this.bookId,
+    this.bookTitle,
+    this.actionId,
+    required this.targetRoute,
+  });
+
+  factory NotificationPayload.fromJson(String? raw) {
+    if (raw == null || raw.isEmpty) {
+      throw const FormatException('Empty notification payload');
+    }
+
+    final map = jsonDecode(raw) as Map<String, dynamic>;
+    final typeIndex = map['type'] as int?;
+    if (typeIndex == null ||
+        typeIndex < 0 ||
+        typeIndex >= NotificationType.values.length) {
+      throw const FormatException('Unknown notification type');
+    }
+
+    return NotificationPayload(
+      type: NotificationType.values[typeIndex],
+      bookId: map['bookId'] as int?,
+      bookTitle: map['bookTitle'] as String?,
+      actionId: map['actionId'] as int?,
+      targetRoute: map['route'] as String? ?? '/',
+    );
+  }
+
+  final NotificationType type;
+  final int? bookId;
+  final String? bookTitle;
+  final int? actionId;
+  final String targetRoute;
+
+  String encode() {
+    return jsonEncode({
+      'type': type.index,
+      'bookId': bookId,
+      'bookTitle': bookTitle,
+      'actionId': actionId,
+      'route': targetRoute,
+    });
+  }
+}
 
 class NotificationService {
   NotificationService();
@@ -10,29 +80,23 @@ class NotificationService {
       FlutterLocalNotificationsPlugin();
 
   bool _initialized = false;
+  void Function(NotificationResponse)? _onSelectNotification;
 
   static const _dailyReminderId = 1;
   static const _reflectionPromptId = 2;
+  static const _continueReadingId = 3;
+  static const _actionPlanBaseId = 5000;
 
   Future<void> initialize() async {
     if (_initialized) {
       return;
     }
 
-    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const darwinInit = DarwinInitializationSettings(
-      requestAlertPermission: false,
-      requestBadgePermission: false,
-      requestSoundPermission: false,
+    await _plugin.initialize(
+      _buildInitializationSettings(),
+      onDidReceiveNotificationResponse: _onSelectNotification,
+      onDidReceiveBackgroundNotificationResponse: _onSelectNotification,
     );
-
-    final settings = const InitializationSettings(
-      android: androidInit,
-      iOS: darwinInit,
-      macOS: darwinInit,
-    );
-
-    await _plugin.initialize(settings);
     tz.initializeTimeZones();
     _setLocalTimezone();
 
@@ -73,10 +137,48 @@ class NotificationService {
     return androidGranted || iosGranted || macGranted;
   }
 
-  Future<void> scheduleDailyReminder(TimeOfDay time) async {
+  void registerSelectNotificationHandler(
+    void Function(NotificationResponse) onSelectNotification,
+  ) {
+    _onSelectNotification = onSelectNotification;
+
+    if (_initialized) {
+      _plugin.initialize(
+        _buildInitializationSettings(),
+        onDidReceiveNotificationResponse: _onSelectNotification,
+        onDidReceiveBackgroundNotificationResponse: _onSelectNotification,
+      );
+    }
+  }
+
+  Future<NotificationPayload?> getLaunchPayload() async {
+    await initialize();
+    final launchDetails = await _plugin.getNotificationAppLaunchDetails();
+    final payload = launchDetails?.notificationResponse?.payload;
+    if (payload == null) {
+      return null;
+    }
+
+    try {
+      return NotificationPayload.fromJson(payload);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> scheduleReadingReminder(
+    TimeOfDay time, {
+    ReminderFrequency frequency = ReminderFrequency.daily,
+    int weeklyWeekday = DateTime.monday,
+  }) async {
     await initialize();
 
-    final scheduledDate = _nextInstance(time);
+    final scheduledDate = _nextInstance(time, weeklyWeekday, frequency);
+
+    final payload = NotificationPayload(
+      type: NotificationType.readingReminder,
+      targetRoute: '/reading-speed',
+    );
 
     await _plugin.zonedSchedule(
       _dailyReminderId,
@@ -98,13 +200,111 @@ class NotificationService {
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.wallClockTime,
-      matchDateTimeComponents: DateTimeComponents.time,
+      matchDateTimeComponents: frequency == ReminderFrequency.daily
+          ? DateTimeComponents.time
+          : DateTimeComponents.dayOfWeekAndTime,
+      payload: payload.encode(),
     );
   }
 
   Future<void> cancelDailyReminder() async {
     await initialize();
     await _plugin.cancel(_dailyReminderId);
+  }
+
+  Future<void> scheduleContinueReadingReminder({
+    required int bookId,
+    required String bookTitle,
+    required TimeOfDay time,
+    ReminderFrequency frequency = ReminderFrequency.daily,
+    int weeklyWeekday = DateTime.monday,
+  }) async {
+    await initialize();
+
+    final scheduledDate = _nextInstance(time, weeklyWeekday, frequency);
+
+    final payload = NotificationPayload(
+      type: NotificationType.continueReading,
+      bookId: bookId,
+      bookTitle: bookTitle,
+      targetRoute: '/reading-speed?bookId=$bookId',
+    );
+
+    await _plugin.zonedSchedule(
+      _continueReadingId,
+      '「$bookTitle」の続き、読みませんか？',
+      '読んだところから再開しましょう。',
+      scheduledDate,
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          'continue_reading',
+          'Continue Reading Reminder',
+          channelDescription: '読書中の本に戻るためのリマインダー',
+          importance: Importance.high,
+          priority: Priority.high,
+        ),
+        iOS: const DarwinNotificationDetails(),
+        macOS: const DarwinNotificationDetails(),
+      ),
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.wallClockTime,
+      matchDateTimeComponents: frequency == ReminderFrequency.daily
+          ? DateTimeComponents.time
+          : DateTimeComponents.dayOfWeekAndTime,
+      payload: payload.encode(),
+    );
+  }
+
+  Future<void> cancelContinueReadingReminder() async {
+    await initialize();
+    await _plugin.cancel(_continueReadingId);
+  }
+
+  Future<void> scheduleActionPlanReminder({
+    required int actionId,
+    required String actionTitle,
+    required DateTime remindAt,
+    int? bookId,
+    String? bookTitle,
+  }) async {
+    await initialize();
+
+    final payload = NotificationPayload(
+      type: NotificationType.actionPlanDue,
+      actionId: actionId,
+      bookId: bookId,
+      bookTitle: bookTitle,
+      targetRoute:
+          bookId != null ? '/actions?bookId=$bookId' : '/actions',
+    );
+
+    await _plugin.zonedSchedule(
+      _actionPlanBaseId + actionId,
+      'アクションプランの期限',
+      '$actionTitle${bookTitle != null ? '（$bookTitle）' : ''}',
+      tz.TZDateTime.from(remindAt, tz.local),
+      NotificationDetails(
+        android: AndroidNotificationDetails(
+          'action_plan_due',
+          'Action Plan Reminder',
+          channelDescription: '読書後の行動アイデアを思い出すための通知',
+          importance: Importance.high,
+          priority: Priority.high,
+        ),
+        iOS: const DarwinNotificationDetails(),
+        macOS: const DarwinNotificationDetails(),
+      ),
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      payload: payload.encode(),
+    );
+  }
+
+  Future<void> cancelActionPlanReminder(int actionId) async {
+    await initialize();
+    await _plugin.cancel(_actionPlanBaseId + actionId);
   }
 
   Future<void> showReflectionPrompt() async {
@@ -128,7 +328,11 @@ class NotificationService {
     );
   }
 
-  tz.TZDateTime _nextInstance(TimeOfDay time) {
+  tz.TZDateTime _nextInstance(
+    TimeOfDay time,
+    int weeklyWeekday,
+    ReminderFrequency frequency,
+  ) {
     final now = tz.TZDateTime.now(tz.local);
     var scheduled = tz.TZDateTime(
       tz.local,
@@ -139,11 +343,33 @@ class NotificationService {
       time.minute,
     );
 
+    if (frequency == ReminderFrequency.weekly) {
+      while (scheduled.weekday != weeklyWeekday || !scheduled.isAfter(now)) {
+        scheduled = scheduled.add(const Duration(days: 1));
+      }
+      return scheduled;
+    }
+
     if (!scheduled.isAfter(now)) {
       scheduled = scheduled.add(const Duration(days: 1));
     }
 
     return scheduled;
+  }
+
+  InitializationSettings _buildInitializationSettings() {
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const darwinInit = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+
+    return const InitializationSettings(
+      android: androidInit,
+      iOS: darwinInit,
+      macOS: darwinInit,
+    );
   }
 
   void _setLocalTimezone() {

--- a/lib/features/reading_speed/reading_speed_feature.dart
+++ b/lib/features/reading_speed/reading_speed_feature.dart
@@ -293,7 +293,9 @@ class _ReadingStats {
 }
 
 class ReadingSpeedPage extends ConsumerStatefulWidget {
-  const ReadingSpeedPage({super.key});
+  const ReadingSpeedPage({super.key, this.initialBookId});
+
+  final int? initialBookId;
 
   @override
   ConsumerState<ReadingSpeedPage> createState() => _ReadingSpeedPageState();
@@ -302,6 +304,7 @@ class ReadingSpeedPage extends ConsumerStatefulWidget {
 class _ReadingSpeedPageState extends ConsumerState<ReadingSpeedPage> {
   final _pagesController = TextEditingController();
   final _durationController = TextEditingController();
+  bool _initialBookApplied = false;
 
   @override
   void dispose() {
@@ -313,6 +316,8 @@ class _ReadingSpeedPageState extends ConsumerState<ReadingSpeedPage> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(readingSpeedNotifierProvider);
+
+    _maybeApplyInitialSelection(state);
 
     return Scaffold(
       appBar: AppBar(
@@ -345,6 +350,19 @@ class _ReadingSpeedPageState extends ConsumerState<ReadingSpeedPage> {
         ),
       ),
     );
+  }
+
+  void _maybeApplyInitialSelection(ReadingSpeedState state) {
+    if (_initialBookApplied || widget.initialBookId == null) {
+      return;
+    }
+
+    if (state.books.any((book) => book.id == widget.initialBookId)) {
+      ref
+          .read(readingSpeedNotifierProvider.notifier)
+          .selectBook(widget.initialBookId!);
+      _initialBookApplied = true;
+    }
   }
 }
 
@@ -543,6 +561,10 @@ class _ReadingLogForm extends ConsumerWidget {
           pagesRead: pages,
           durationMinutes: duration,
         );
+
+    await ref
+        .read(notificationSettingsNotifierProvider.notifier)
+        .refreshContinueReadingReminder();
 
     await ref
         .read(notificationSettingsNotifierProvider.notifier)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'core/routing/app_router.dart';
 import 'core/providers/settings_providers.dart';
 import 'core/services/supabase_service.dart';
 import 'core/theme/theme.dart';
+import 'core/providers/notification_providers.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -33,6 +34,9 @@ class BookMemolyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Setup notification navigation handler
+    ref.watch(notificationNavigationProvider);
+
     final router = ref.watch(appRouterProvider);
     final fontScale = ref.watch(fontScaleProvider);
     final themeMode = ref.watch(themeModeProvider);


### PR DESCRIPTION
## Summary
- add notification payload handling and deep links so taps navigate to the correct screen
- expand reminder settings with daily/weekly cadence, continue-reading, and action plan toggles with persistence
- schedule continue reading and action plan reminders based on local data and selected timing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692588b097d0832992fac219749330f6)