### PR TITLE
Fix book registration button enable condition

### DIFF
--- a/lib/features/search/search_feature.dart
+++ b/lib/features/search/search_feature.dart
@@ -2139,9 +2139,9 @@ class _BookRegistrationCard extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           PrimaryButton(
-            onPressed: isLoading ? null : onSave,
-            icon: isRegistered ? AppIcons.save : AppIcons.addLibrary,
-            label: isRegistered ? 'ステータスを更新' : '本を登録',
+            onPressed: (!isRegistered && !isLoading) ? onSave : null,
+            icon: isRegistered ? AppIcons.check : AppIcons.addLibrary,
+            label: isRegistered ? '登録済み' : '本を登録',
             expand: true,
           ),
         ],


### PR DESCRIPTION
## Summary
- enable the book registration button only when the book is not yet registered and data is not loading
- update the button label and icon to reflect registered state when disabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925aed236c883299936653ebfd29066)